### PR TITLE
*BREAKING* Add ability to set pinger request path

### DIFF
--- a/example/weather/services/front/cmd/front/main.go
+++ b/example/weather/services/front/cmd/front/main.go
@@ -109,8 +109,8 @@ func main() {
 
 	// 6. Mount health check & metrics on separate HTTP server (different listen port)
 	check := health.Handler(health.NewChecker(
-		health.NewPinger("locator", "http", *locatorHealthAddr),
-		health.NewPinger("forecaster", "http", *forecasterHealthAddr)))
+		health.NewPinger("locator", *locatorHealthAddr),
+		health.NewPinger("forecaster", *forecasterHealthAddr)))
 	check = log.HTTP(ctx)(check).(http.HandlerFunc)
 	http.Handle("/healthz", check)
 	http.Handle("/livez", check)

--- a/health/pinger.go
+++ b/health/pinger.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/url"
 )
 
 type (
@@ -16,20 +17,30 @@ type (
 		Ping(context.Context) error
 	}
 
+	// Option configures a Pinger.
+	Option func(o *options)
+
 	client struct {
 		name string
 		req  *http.Request
 	}
+
+	options struct {
+		scheme string
+		path   string
+	}
 )
 
-// NewPinger returns a new health-check client for the given service.
-// NewPinger panics if the given host address is malformed.
-func NewPinger(name, scheme, addr string) Pinger {
-	if scheme == "" {
-		scheme = "http"
+// NewPinger returns a new health-check client for the given service. It panics
+// if the given host address is malformed.  The default scheme is "http" and the
+// default path is "/livez". Both can be overridden via options.
+func NewPinger(name, addr string, opts ...Option) Pinger {
+	options := &options{scheme: "http", path: "/livez"}
+	for _, o := range opts {
+		o(options)
 	}
-	url := scheme + "://" + addr + "/livez"
-	req, err := http.NewRequest("GET", url, nil)
+	u := url.URL{Scheme: options.scheme, Host: addr, Path: options.path}
+	req, err := http.NewRequest("GET", u.String(), nil)
 	if err != nil {
 		panic(err)
 	}
@@ -53,4 +64,20 @@ func (c *client) Ping(ctx context.Context) error {
 		return fmt.Errorf("health-check for %q returned status %d", c.name, resp.StatusCode)
 	}
 	return nil
+}
+
+// WithScheme sets the scheme used to ping the service.
+// Default scheme is "http".
+func WithScheme(scheme string) Option {
+	return func(o *options) {
+		o.scheme = scheme
+	}
+}
+
+// WithPath sets the path used to ping the service.
+// Default path is "/livez".
+func WithPath(path string) Option {
+	return func(o *options) {
+		o.path = path
+	}
 }


### PR DESCRIPTION
This commit adds the ability to override the default path used by the
pinger to make health check requests to downstream dependencies.
It introduces options when creating a pinger and makes the scheme an
option. As a result the signature of the `NewPinger` function is now
different:
Before:
```
NewPinger("foo", "http", fooAddr)
```
Now:
```
NewPinger("foo", fooAddr)
```
or
```
NewPinger("foo", fooAddr, health.WithScheme("https"))
```