### PR TITLE
fix(log): FormatJSON has to properly encode strings with quotes

### DIFF
--- a/log/format.go
+++ b/log/format.go
@@ -2,6 +2,7 @@ package log
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"strconv"
 	"time"
@@ -119,9 +120,8 @@ func writeJSON(val interface{}, b *bytes.Buffer) {
 	case nil:
 		b.WriteString("null")
 	case string:
-		b.WriteByte('"')
-		b.WriteString(v)
-		b.WriteByte('"')
+		res, _ := json.Marshal(v)
+		b.Write(res)
 	case int, int32, int64, uint, uint32, uint64:
 		b.WriteString(fmt.Sprintf("%d", v))
 	case float32:
@@ -133,9 +133,8 @@ func writeJSON(val interface{}, b *bytes.Buffer) {
 	case []string:
 		b.WriteByte('[')
 		for j := 0; j < len(v); j++ {
-			b.WriteByte('"')
-			b.WriteString(v[j])
-			b.WriteByte('"')
+			res, _ := json.Marshal(v[j])
+			b.Write(res)
 			if j < len(v)-1 {
 				b.WriteByte(',')
 			}
@@ -232,8 +231,7 @@ func writeJSON(val interface{}, b *bytes.Buffer) {
 		}
 		b.WriteByte(']')
 	default:
-		b.WriteByte('"')
-		b.WriteString(fmt.Sprintf("%v", v))
-		b.WriteByte('"')
+		res, _ := json.Marshal(fmt.Sprintf("%v", v))
+		b.Write(res)
 	}
 }

--- a/log/format_test.go
+++ b/log/format_test.go
@@ -16,6 +16,7 @@ func TestFormat(t *testing.T) {
 
 	keyVals := []KV{
 		{"string", "val"},
+		{"stringWithQuotes", `example "val"`},
 		{"int", 1},
 		{"int32", int32(2)},
 		{"int64", int64(3)},
@@ -28,6 +29,7 @@ func TestFormat(t *testing.T) {
 		{"nil", nil},
 		{"dur", 123 * time.Millisecond},
 		{"sliceString", []string{"a", "b", "c"}},
+		{"sliceStringWithQuotes", []string{"example \"a\""}},
 		{"sliceInt", []int{1, 1}},
 		{"sliceInt32", []int32{2, 2}},
 		{"sliceInt64", []int64{3, 3}},
@@ -42,6 +44,7 @@ func TestFormat(t *testing.T) {
 	}
 
 	formattedKeyVals := "string=val " +
+		`stringWithQuotes="example \"val\"" ` +
 		"int=1 " +
 		"int32=2 " +
 		"int64=3 " +
@@ -54,6 +57,7 @@ func TestFormat(t *testing.T) {
 		"nil=null " +
 		"dur=123ms " +
 		`sliceString="[\"a\",\"b\",\"c\"]" ` +
+		`sliceStringWithQuotes="[\"example \\\"a\\\"\"]" ` +
 		"sliceInt=[1,1] " +
 		"sliceInt32=[2,2] " +
 		"sliceInt64=[3,3] " +
@@ -68,6 +72,7 @@ func TestFormat(t *testing.T) {
 
 	coloredKeyVals := func(col string) string {
 		return col + "string\033[0m=val " +
+			col + "stringWithQuotes\033[0m=example \"val\" " +
 			col + "int\033[0m=1 " +
 			col + "int32\033[0m=2 " +
 			col + "int64\033[0m=3 " +
@@ -80,6 +85,7 @@ func TestFormat(t *testing.T) {
 			col + "nil\033[0m=<nil> " +
 			col + "dur\033[0m=123ms " +
 			col + "sliceString\033[0m=[a b c] " +
+			col + "sliceStringWithQuotes\033[0m=[example \"a\"] " +
 			col + "sliceInt\033[0m=[1 1] " +
 			col + "sliceInt32\033[0m=[2 2] " +
 			col + "sliceInt64\033[0m=[3 3] " +
@@ -94,6 +100,7 @@ func TestFormat(t *testing.T) {
 	}
 
 	jsonKeyVals := `"string":"val",` +
+		`"stringWithQuotes":"example \"val\"",` +
 		`"int":1,` +
 		`"int32":2,` +
 		`"int64":3,` +
@@ -106,6 +113,7 @@ func TestFormat(t *testing.T) {
 		`"nil":null,` +
 		`"dur":"123ms",` +
 		`"sliceString":["a","b","c"],` +
+		`"sliceStringWithQuotes":["example \"a\""],` +
 		`"sliceInt":[1,1],` +
 		`"sliceInt32":[2,2],` +
 		`"sliceInt64":[3,3],` +


### PR DESCRIPTION
Fixing a bug with FormatJSON where strings with quotes would result in invalid JSON being logged.