### PR TITLE
feat(trace): Configurable exporter and allow fetching the underlying provider

### DIFF
--- a/example/weather/README.md
+++ b/example/weather/README.md
@@ -106,7 +106,7 @@ traces to the agent:
 conn, err := grpc.DialContext(ctx, *collectorAddr,
 	grpc.WithTransportCredentials(insecure.NewCredentials()),
 	grpc.WithBlock())
-ctx, err = trace.Context(ctx, genfront.ServiceName, conn)
+ctx, err = trace.Context(ctx, genfront.ServiceName, trace.WithGRPCExporter(conn))
 ```
 
 gRPC services use the `trace.UnaryServerInterceptor` to create a span for each

--- a/example/weather/services/forecaster/cmd/forecaster/main.go
+++ b/example/weather/services/forecaster/cmd/forecaster/main.go
@@ -60,7 +60,7 @@ func main() {
 		os.Exit(1)
 	}
 	log.Debugf(ctx, "connected to Grafana agent %s", *agentaddr)
-	ctx, err = trace.Context(ctx, genforecaster.ServiceName, conn)
+	ctx, err = trace.Context(ctx, genforecaster.ServiceName, trace.WithGRPCExporter(conn))
 	if err != nil {
 		log.Errorf(ctx, err, "failed to initialize tracing")
 		os.Exit(1)

--- a/example/weather/services/front/cmd/front/main.go
+++ b/example/weather/services/front/cmd/front/main.go
@@ -62,7 +62,7 @@ func main() {
 		os.Exit(1)
 	}
 	log.Debugf(ctx, "connected to Grafana agent %s", *agentaddr)
-	ctx, err = trace.Context(ctx, genfront.ServiceName, conn)
+	ctx, err = trace.Context(ctx, genfront.ServiceName, trace.WithGRPCExporter(conn))
 	if err != nil {
 		log.Errorf(ctx, err, "failed to initialize tracing")
 		os.Exit(1)

--- a/example/weather/services/locator/cmd/locator/main.go
+++ b/example/weather/services/locator/cmd/locator/main.go
@@ -60,7 +60,7 @@ func main() {
 		os.Exit(1)
 	}
 	log.Debugf(ctx, "connected to Grafana agent %s", *agentaddr)
-	ctx, err = trace.Context(ctx, genlocator.ServiceName, conn)
+	ctx, err = trace.Context(ctx, genlocator.ServiceName, trace.WithGRPCExporter(conn))
 	if err != nil {
 		log.Errorf(ctx, err, "failed to initialize tracing")
 		os.Exit(1)

--- a/trace/README.md
+++ b/trace/README.md
@@ -28,7 +28,7 @@ package `github.com/repo/services/svc`
 
 ```go
 package main
-        
+
 import (
        "context"
 
@@ -40,7 +40,7 @@ import (
         httpsvrgen "github.com/repo/services/svc/gen/http/svc/server"
        	grpcsvrgen "github.com/repo/services/svc/gen/grpc/svc/server"
        	svcgen "github.com/repo/services/svc/gen/svc"
-)       
+)
 
 func main() {
         // Initialize the log context
@@ -61,7 +61,7 @@ func main() {
                 log.Error(ctx, "unable to connect to span collector", "err", err)
                 os.Exit(1)
         }
-        ctx = trace.Context(ctx, svcgen.ServiceName, conn)
+        ctx = trace.Context(ctx, svcgen.ServiceName, trace.WithGRPCExporter(conn))
 
         // ** Trace HTTP requests **
         handler := trace.HTTP(ctx)(mux)
@@ -81,7 +81,7 @@ func main() {
 ### Making Requests to Downstream Dependencies
 
 For tracing to work appropriately all clients to downstream dependencies must be
-configured using the appropriate trace package function. 
+configured using the appropriate trace package function.
 
 For HTTP dependencies the trace package provides a `Client` function that can be
 used to configure a `http.RoundTripper` to trace all requests made through it.
@@ -142,7 +142,7 @@ this package adds the following attributes to HTTP requests:
 * `http.request_content_length`: The length of the request body if any.
 * `enduser.id`: The request basic auth username if any.
 * `net.transport`: One of `ip_tcp`, `ip_udp`, `ip`, `unix` or `other`.
-* `net.peer.ip`, `net.peer.name`, `net.peer.port`: The IP address, port and name 
+* `net.peer.ip`, `net.peer.name`, `net.peer.port`: The IP address, port and name
   of the remote peer if available in the request `RemoteAddr` field.
 * `net.host.ip`, `net.host.name`, `net.host.port`: The IP address, port and name
   of the remote host if available in the request `Host` field, the request `Host`
@@ -181,7 +181,7 @@ is not traced or the context not initialized with `trace.Context`.
 
 ```go
 // Add an event to the current span
-trace.AddEvent(ctx, "operation completed", "operation_id", operationID, "status", status) 
+trace.AddEvent(ctx, "operation completed", "operation_id", operationID, "status", status)
 ```
 
 ### Span Status And Error

--- a/trace/context_test.go
+++ b/trace/context_test.go
@@ -10,8 +10,8 @@ import (
 func TestContext(t *testing.T) {
 	// We don't want to test otel, keep it simple...
 	exporter := tracetest.NewInMemoryExporter()
-	ctx, err := Context(context.Background(), "test", nil,
-		WithMaxSamplingRate(3), WithSampleSize(20), withExporter(exporter))
+	ctx, err := Context(context.Background(), "test",
+		WithMaxSamplingRate(3), WithSampleSize(20), WithExporter(exporter))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -29,7 +29,7 @@ func TestContext(t *testing.T) {
 }
 
 func TestDisabled(t *testing.T) {
-	ctx, err := Context(context.Background(), "test", nil, WithDisabled())
+	ctx, err := Context(context.Background(), "test", WithDisabled())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -52,15 +52,15 @@ func TestDisabled(t *testing.T) {
 
 func TestIsTraced(t *testing.T) {
 	exporter := tracetest.NewInMemoryExporter()
-	ctx, err := Context(context.Background(), "test", nil,
-		WithMaxSamplingRate(3), WithSampleSize(20), withExporter(exporter))
+	ctx, err := Context(context.Background(), "test",
+		WithMaxSamplingRate(3), WithSampleSize(20), WithExporter(exporter))
 	if err != nil {
 		t.Fatal(err)
 	}
 	if IsTraced(ctx) {
 		t.Error("expected not traced")
 	}
-	ctx, err = Context(ctx, "test", nil, WithMaxSamplingRate(3), WithSampleSize(20), withExporter(exporter))
+	ctx, err = Context(ctx, "test", WithMaxSamplingRate(3), WithSampleSize(20), WithExporter(exporter))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/trace/http.go
+++ b/trace/http.go
@@ -34,7 +34,7 @@ const errContextMissing = "context not initialized for tracing, use trace.Contex
 //          os.Exit(1)
 //      }
 //      // Initialize context for tracing
-//      ctx := trace.Context(ctx, svcgen.ServiceName, conn)
+//      ctx := trace.Context(ctx, svcgen.ServiceName, trace.WithGRPCExporter(conn))
 //      // Mount middleware
 // 	handler := trace.HTTP(ctx)(mux)
 //

--- a/trace/options.go
+++ b/trace/options.go
@@ -1,7 +1,11 @@
 package trace
 
 import (
+	"context"
+
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"google.golang.org/grpc"
 )
 
 type (
@@ -13,7 +17,7 @@ type (
 	}
 
 	// TraceOption is a function that configures a provider.
-	TraceOption func(opts *options)
+	TraceOption func(ctx context.Context, opts *options) error
 )
 
 // defaultOptions returns the default sampler options.
@@ -26,29 +30,44 @@ func defaultOptions() *options {
 
 // WithMaxSamplingRate sets the maximum sampling rate in requests per second.
 func WithMaxSamplingRate(rate int) TraceOption {
-	return func(opts *options) {
+	return func(ctx context.Context, opts *options) error {
 		opts.maxSamplingRate = rate
+		return nil
 	}
 }
 
 // WithSampleSize sets the number of requests between two adjustments of the
 // sampling rate.
 func WithSampleSize(size int) TraceOption {
-	return func(opts *options) {
+	return func(ctx context.Context, opts *options) error {
 		opts.sampleSize = size
+		return nil
 	}
 }
 
 // WithDisabled disables tracing, not for use in production.
 func WithDisabled() TraceOption {
-	return func(opts *options) {
+	return func(ctx context.Context, opts *options) error {
 		opts.disabled = true
+		return nil
 	}
 }
 
-// withExporter sets the exporter to use. This is intended for tests.
-func withExporter(exporter sdktrace.SpanExporter) TraceOption {
-	return func(opts *options) {
+// WithExporter sets the exporter to use.
+func WithExporter(exporter sdktrace.SpanExporter) TraceOption {
+	return func(ctx context.Context, opts *options) error {
 		opts.exporter = exporter
+		return nil
+	}
+}
+
+func WithGRPCExporter(conn *grpc.ClientConn) TraceOption {
+	return func(ctx context.Context, opts *options) error {
+		exporter, err := otlptracegrpc.New(ctx, otlptracegrpc.WithGRPCConn(conn))
+		if err != nil {
+			return err
+		}
+		opts.exporter = exporter
+		return nil
 	}
 }

--- a/trace/options_test.go
+++ b/trace/options_test.go
@@ -1,12 +1,15 @@
 package trace
 
 import (
+	"context"
 	"testing"
 
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 )
 
 func TestOptions(t *testing.T) {
+	ctx := context.Background()
+
 	options := defaultOptions()
 	if options.maxSamplingRate != 2 {
 		t.Errorf("got %d, want 2", options.maxSamplingRate)
@@ -14,19 +17,19 @@ func TestOptions(t *testing.T) {
 	if options.sampleSize != 10 {
 		t.Errorf("got %d, want 10", options.sampleSize)
 	}
-	WithMaxSamplingRate(3)(options)
+	WithMaxSamplingRate(3)(ctx, options)
 	if options.maxSamplingRate != 3 {
 		t.Errorf("got %d sampling rate, want 3", options.maxSamplingRate)
 	}
-	WithSampleSize(20)(options)
+	WithSampleSize(20)(ctx, options)
 	if options.sampleSize != 20 {
 		t.Errorf("got %d sample size, want 20", options.sampleSize)
 	}
-	WithDisabled()(options)
+	WithDisabled()(ctx, options)
 	if !options.disabled {
 		t.Error("expected disabled to be true")
 	}
-	withExporter(tracetest.NewInMemoryExporter())(options)
+	WithExporter(tracetest.NewInMemoryExporter())(ctx, options)
 	if options.exporter == nil {
 		t.Error("got nil exporter, want non-nil")
 	}


### PR DESCRIPTION
⚠️ This is a breaking change, since it changes the signature of `Context`

Rationale: people should be able to set their own exporters.

As an example, when using Google Cloud, you would do something like this:

```go
import (
        "context"
        "log"
        "os"

        texporter "github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace"
        "goa.design/clue/trace"
)

func main() {
        // Create exporter.
        ctx := context.Background()
        projectID := os.Getenv("GOOGLE_CLOUD_PROJECT")
        exporter, err := texporter.New(texporter.WithProjectID(projectID))
        if err != nil {
                log.Fatalf("texporter.NewExporter: %v", err)
        }

        ctx = trace.Context(ctx, "service", trace.WithExporter(exporter))
        defer trace.TraceProvider(ctx).ForceFlush(ctx)

        // ...
}
```

I opted for `trace.WithExporter` rather than requiring an exporter param so we have more flexibility to make non-breaking changes. E.g: I added `trace.WithGRPCExporter(conn)` so it's easy to migrate existing users.