### PR TITLE
closes #68: Add a function to inject a logger into a context

### DIFF
--- a/log/context.go
+++ b/log/context.go
@@ -23,6 +23,9 @@ func Context(ctx context.Context, opts ...LogOption) context.Context {
 	return context.WithValue(ctx, ctxLogger, l)
 }
 
+// WithContext will inject the second context in the given one.
+//
+// It is useful when building middleware handlers such as log.HTTP
 func WithContext(parentCtx, logCtx context.Context) context.Context {
 	logger, ok := logCtx.Value(ctxLogger).(*logger)
 	if !ok {
@@ -31,6 +34,10 @@ func WithContext(parentCtx, logCtx context.Context) context.Context {
 	return context.WithValue(parentCtx, ctxLogger, logger)
 }
 
+// MustContainLogger will panic if the given context is missing the logger.
+//
+// It can be used during server initialisation when you have a function or
+// middleware that you want to ensure receives a context with a logger.
 func MustContainLogger(logCtx context.Context) {
 	_, ok := logCtx.Value(ctxLogger).(*logger)
 	if !ok {

--- a/log/context.go
+++ b/log/context.go
@@ -1,0 +1,39 @@
+package log
+
+import "context"
+
+const (
+	ctxLogger ctxKey = iota + 1
+)
+
+// Context initializes a context for logging.
+func Context(ctx context.Context, opts ...LogOption) context.Context {
+	l, ok := ctx.Value(ctxLogger).(*logger)
+	if !ok {
+		l = &logger{options: defaultOptions()}
+	}
+	l.lock.Lock()
+	defer l.lock.Unlock()
+	for _, opt := range opts {
+		opt(l.options)
+	}
+	if l.options.disableBuffering != nil && l.options.disableBuffering(ctx) {
+		l.flush()
+	}
+	return context.WithValue(ctx, ctxLogger, l)
+}
+
+func WithContext(parentCtx, logCtx context.Context) context.Context {
+	logger, ok := logCtx.Value(ctxLogger).(*logger)
+	if !ok {
+		return parentCtx
+	}
+	return context.WithValue(parentCtx, ctxLogger, logger)
+}
+
+func MustContainLogger(logCtx context.Context) {
+	_, ok := logCtx.Value(ctxLogger).(*logger)
+	if !ok {
+		panic("log.HTTP called without log.Context")
+	}
+}

--- a/log/context.go
+++ b/log/context.go
@@ -41,6 +41,6 @@ func WithContext(parentCtx, logCtx context.Context) context.Context {
 func MustContainLogger(logCtx context.Context) {
 	_, ok := logCtx.Value(ctxLogger).(*logger)
 	if !ok {
-		panic("log.HTTP called without log.Context")
+		panic("provided a context without a logger. Use log.Context")
 	}
 }

--- a/log/grpc.go
+++ b/log/grpc.go
@@ -11,18 +11,14 @@ import (
 // context with the logger contained in logCtx.  It panics if logCtx was not
 // initialized with Context.
 func UnaryServerInterceptor(logCtx context.Context) grpc.UnaryServerInterceptor {
-	l := logCtx.Value(ctxLogger)
-	if l == nil {
-		panic("log.Init called without log.Context")
-	}
-	logger := l.(*logger)
+	MustContainLogger(logCtx)
 	return func(
 		ctx context.Context,
 		req interface{},
 		info *grpc.UnaryServerInfo,
 		handler grpc.UnaryHandler,
 	) (interface{}, error) {
-		ctx = context.WithValue(ctx, ctxLogger, logger)
+		ctx = WithContext(ctx, logCtx)
 		if reqID := ctx.Value(middleware.RequestIDKey); reqID != nil {
 			ctx = With(ctx, KV{"requestID", reqID})
 		}
@@ -34,18 +30,14 @@ func UnaryServerInterceptor(logCtx context.Context) grpc.UnaryServerInterceptor 
 // request context with the logger contained in logCtx.  It panics if logCtx
 // was not initialized with Context.
 func StreamServerInterceptor(logCtx context.Context) grpc.StreamServerInterceptor {
-	l := logCtx.Value(ctxLogger)
-	if l == nil {
-		panic("log.Init called without log.Context")
-	}
-	logger := l.(*logger)
+	MustContainLogger(logCtx)
 	return func(
 		srv interface{},
 		stream grpc.ServerStream,
 		info *grpc.StreamServerInfo,
 		handler grpc.StreamHandler,
 	) error {
-		ctx := context.WithValue(stream.Context(), ctxLogger, logger)
+		ctx := WithContext(stream.Context(), logCtx)
 		if reqID := ctx.Value(middleware.RequestIDKey); reqID != nil {
 			ctx = With(ctx, KV{"requestID", reqID})
 		}

--- a/log/http.go
+++ b/log/http.go
@@ -10,14 +10,10 @@ import (
 // HTTP returns a HTTP middleware that initializes the logger context.  It
 // panics if logCtx was not initialized with Context.
 func HTTP(logCtx context.Context) func(http.Handler) http.Handler {
-	l := logCtx.Value(ctxLogger)
-	if l == nil {
-		panic("log.HTTP called without log.Context")
-	}
-	logger := l.(*logger)
+	MustContainLogger(logCtx)
 	return func(h http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-			ctx := context.WithValue(req.Context(), ctxLogger, logger)
+			ctx := WithContext(req.Context(), logCtx)
 			if requestID := req.Context().Value(middleware.RequestIDKey); requestID != nil {
 				ctx = With(ctx, KV{"requestID", requestID})
 			}

--- a/log/log.go
+++ b/log/log.go
@@ -48,34 +48,11 @@ const (
 	SeverityError
 )
 
-const (
-	ctxLogger ctxKey = iota + 1
-)
-
 // Be kind to tests
 var (
 	timeNow = time.Now
 	osExit  = os.Exit
 )
-
-// Context initializes a context for logging.
-func Context(ctx context.Context, opts ...LogOption) context.Context {
-	var l *logger
-	if v := ctx.Value(ctxLogger); v != nil {
-		l = v.(*logger)
-	} else {
-		l = &logger{options: defaultOptions()}
-	}
-	l.lock.Lock()
-	defer l.lock.Unlock()
-	for _, opt := range opts {
-		opt(l.options)
-	}
-	if l.options.disableBuffering != nil && l.options.disableBuffering(ctx) {
-		l.flush()
-	}
-	return context.WithValue(ctx, ctxLogger, l)
-}
 
 // Debug writes the key/value pairs to the log output if the log context is
 // configured to log debug messages (via WithDebug).


### PR DESCRIPTION
This will make it easier for people to develop their own middlewares.

As an example, we are going to build our own `HTTP` middleware for GCP which uses a `trace` field rather than `requestID`.