### PR TITLE
feat(trace): Add support for configurable propagators

### DIFF
--- a/trace/context_test.go
+++ b/trace/context_test.go
@@ -4,8 +4,14 @@ import (
 	"context"
 	"testing"
 
+	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace"
 )
+
+func testContext(provider trace.TracerProvider) context.Context {
+	return withProvider(context.Background(), provider, propagation.TraceContext{}, "test")
+}
 
 func TestContext(t *testing.T) {
 	// We don't want to test otel, keep it simple...

--- a/trace/grpc.go
+++ b/trace/grpc.go
@@ -5,7 +5,6 @@ import (
 
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
 	"goa.design/clue/log"
 	"goa.design/goa/v3/middleware"
@@ -30,7 +29,7 @@ func UnaryServerInterceptor(traceCtx context.Context) grpc.UnaryServerIntercepto
 		handler = addRequestIDGRPCUnary(handler)
 		ui := otelgrpc.UnaryServerInterceptor(
 			otelgrpc.WithTracerProvider(state.(*stateBag).provider),
-			otelgrpc.WithPropagators(propagation.TraceContext{}),
+			otelgrpc.WithPropagators(state.(*stateBag).propagator),
 		)
 		return ui(ctx, req, info, handler)
 	}
@@ -54,7 +53,7 @@ func StreamServerInterceptor(traceCtx context.Context) grpc.StreamServerIntercep
 		handler = addRequestIDGRPCStream(handler)
 		si := otelgrpc.StreamServerInterceptor(
 			otelgrpc.WithTracerProvider(state.(*stateBag).provider),
-			otelgrpc.WithPropagators(propagation.TraceContext{}),
+			otelgrpc.WithPropagators(state.(*stateBag).propagator),
 		)
 		return si(srv, stream, info, handler)
 	}
@@ -70,7 +69,7 @@ func UnaryClientInterceptor(traceCtx context.Context) grpc.UnaryClientIntercepto
 	}
 	return otelgrpc.UnaryClientInterceptor(
 		otelgrpc.WithTracerProvider(state.(*stateBag).provider),
-		otelgrpc.WithPropagators(propagation.TraceContext{}))
+		otelgrpc.WithPropagators(state.(*stateBag).propagator))
 }
 
 // StreamClientInterceptor returns an OpenTelemetry StreamClientInterceptor configured
@@ -83,7 +82,7 @@ func StreamClientInterceptor(traceCtx context.Context) grpc.StreamClientIntercep
 	}
 	return otelgrpc.StreamClientInterceptor(
 		otelgrpc.WithTracerProvider(state.(*stateBag).provider),
-		otelgrpc.WithPropagators(propagation.TraceContext{}))
+		otelgrpc.WithPropagators(state.(*stateBag).propagator))
 }
 
 // addRequestIDGRPCUnary is a middleware that adds the request ID to the current span

--- a/trace/grpc_test.go
+++ b/trace/grpc_test.go
@@ -17,7 +17,7 @@ import (
 func TestUnaryServerTrace(t *testing.T) {
 	exporter := tracetest.NewInMemoryExporter()
 	provider := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
-	traceInterceptor := UnaryServerInterceptor(withProvider(context.Background(), provider, "test"))
+	traceInterceptor := UnaryServerInterceptor(testContext(provider))
 	requestIDInterceptor := middleware.UnaryRequestID()
 	cli, stop := testsvc.SetupGRPC(t,
 		testsvc.WithServerOptions(grpc.ChainUnaryInterceptor(requestIDInterceptor, traceInterceptor)),
@@ -59,7 +59,7 @@ func TestUnaryServerTrace(t *testing.T) {
 func TestUnaryServerTraceNoRequestID(t *testing.T) {
 	exporter := tracetest.NewInMemoryExporter()
 	provider := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
-	traceInterceptor := UnaryServerInterceptor(withProvider(context.Background(), provider, "test"))
+	traceInterceptor := UnaryServerInterceptor(testContext(provider))
 	cli, stop := testsvc.SetupGRPC(t,
 		testsvc.WithServerOptions(grpc.UnaryInterceptor(traceInterceptor)),
 		testsvc.WithUnaryFunc(addEventUnaryMethod))
@@ -77,7 +77,7 @@ func TestUnaryServerTraceNoRequestID(t *testing.T) {
 func TestStreamServerTrace(t *testing.T) {
 	exporter := tracetest.NewInMemoryExporter()
 	provider := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
-	traceInterceptor := StreamServerInterceptor(withProvider(context.Background(), provider, "test"))
+	traceInterceptor := StreamServerInterceptor(testContext(provider))
 	requestIDInterceptor := middleware.StreamRequestID()
 	cli, stop := testsvc.SetupGRPC(t,
 		testsvc.WithServerOptions(grpc.ChainStreamInterceptor(requestIDInterceptor, traceInterceptor)),
@@ -110,7 +110,7 @@ func TestStreamServerTrace(t *testing.T) {
 func TestStreamServerTraceNoRequestID(t *testing.T) {
 	exporter := tracetest.NewInMemoryExporter()
 	provider := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
-	traceInterceptor := StreamServerInterceptor(withProvider(context.Background(), provider, "test"))
+	traceInterceptor := StreamServerInterceptor(testContext(provider))
 	cli, stop := testsvc.SetupGRPC(t,
 		testsvc.WithServerOptions(grpc.StreamInterceptor(traceInterceptor)),
 		testsvc.WithStreamFunc(echoMethod))
@@ -133,7 +133,7 @@ func TestUnaryClientTrace(t *testing.T) {
 	exporter := tracetest.NewInMemoryExporter()
 	provider := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
 	cli, stop := testsvc.SetupGRPC(t,
-		testsvc.WithDialOptions(grpc.WithUnaryInterceptor(UnaryClientInterceptor(withProvider(context.Background(), provider, "test")))),
+		testsvc.WithDialOptions(grpc.WithUnaryInterceptor(UnaryClientInterceptor(testContext(provider)))),
 		testsvc.WithUnaryFunc(addEventUnaryMethod))
 	_, err := cli.GRPCMethod(context.Background(), &testsvc.Fields{})
 	if err != nil {
@@ -150,7 +150,7 @@ func TestStreamClientTrace(t *testing.T) {
 	exporter := tracetest.NewInMemoryExporter()
 	provider := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
 	cli, stop := testsvc.SetupGRPC(t,
-		testsvc.WithDialOptions(grpc.WithStreamInterceptor(StreamClientInterceptor(withProvider(context.Background(), provider, "test")))),
+		testsvc.WithDialOptions(grpc.WithStreamInterceptor(StreamClientInterceptor(testContext(provider)))),
 		testsvc.WithStreamFunc(echoMethod))
 	ctx, cancel := context.WithCancel(context.Background())
 	stream, err := cli.GRPCStream(ctx)

--- a/trace/http.go
+++ b/trace/http.go
@@ -6,7 +6,6 @@ import (
 
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
 	"goa.design/clue/log"
 	"goa.design/goa/v3/middleware"
@@ -47,7 +46,7 @@ func HTTP(ctx context.Context) func(http.Handler) http.Handler {
 		h = addRequestIDHTTP(h)
 		return otelhttp.NewHandler(h, s.(*stateBag).svc,
 			otelhttp.WithTracerProvider(s.(*stateBag).provider),
-			otelhttp.WithPropagators(propagation.TraceContext{}))
+			otelhttp.WithPropagators(s.(*stateBag).propagator))
 	}
 }
 
@@ -60,7 +59,7 @@ func Client(ctx context.Context, t http.RoundTripper) http.RoundTripper {
 	}
 	return otelhttp.NewTransport(t,
 		otelhttp.WithTracerProvider(s.(*stateBag).provider),
-		otelhttp.WithPropagators(propagation.TraceContext{}))
+		otelhttp.WithPropagators(s.(*stateBag).propagator))
 }
 
 // addRequestIDHTTP is a middleware that adds the request ID to the current span

--- a/trace/http_test.go
+++ b/trace/http_test.go
@@ -15,7 +15,7 @@ import (
 func TestHTTP(t *testing.T) {
 	exporter := tracetest.NewInMemoryExporter()
 	provider := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
-	ctx := withProvider(context.Background(), provider, "test")
+	ctx := testContext(provider)
 	cli, stop := testsvc.SetupHTTP(t,
 		testsvc.WithHTTPMiddleware(middleware.RequestID(), HTTP(ctx)),
 		testsvc.WithHTTPFunc(addEventUnaryMethod))
@@ -49,7 +49,7 @@ func TestHTTP(t *testing.T) {
 func TestHTTPRequestID(t *testing.T) {
 	exporter := tracetest.NewInMemoryExporter()
 	provider := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
-	ctx := withProvider(context.Background(), provider, "test")
+	ctx := testContext(provider)
 	cli, stop := testsvc.SetupHTTP(t,
 		testsvc.WithHTTPMiddleware(HTTP(ctx)),
 		testsvc.WithHTTPFunc(addEventUnaryMethod))
@@ -66,7 +66,7 @@ func TestHTTPRequestID(t *testing.T) {
 func TestTrace(t *testing.T) {
 	exporter := tracetest.NewInMemoryExporter()
 	provider := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
-	ctx := withProvider(context.Background(), provider, "test")
+	ctx := testContext(provider)
 	c := http.Client{Transport: Client(ctx, http.DefaultTransport)}
 	otelt, ok := c.Transport.(*otelhttp.Transport)
 	if !ok {

--- a/trace/options.go
+++ b/trace/options.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
+	"go.opentelemetry.io/otel/propagation"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"google.golang.org/grpc"
 )
@@ -13,6 +14,7 @@ type (
 		maxSamplingRate int
 		sampleSize      int
 		exporter        sdktrace.SpanExporter
+		propagator      propagation.TextMapPropagator
 		disabled        bool
 	}
 
@@ -25,6 +27,7 @@ func defaultOptions() *options {
 	return &options{
 		maxSamplingRate: 2,
 		sampleSize:      10,
+		propagator:      propagation.TraceContext{},
 	}
 }
 
@@ -57,6 +60,14 @@ func WithDisabled() TraceOption {
 func WithExporter(exporter sdktrace.SpanExporter) TraceOption {
 	return func(ctx context.Context, opts *options) error {
 		opts.exporter = exporter
+		return nil
+	}
+}
+
+// WithPropagator sets the otel propagators
+func WithPropagator(propagator propagation.TextMapPropagator) TraceOption {
+	return func(ctx context.Context, opts *options) error {
+		opts.propagator = propagator
 		return nil
 	}
 }

--- a/trace/span_test.go
+++ b/trace/span_test.go
@@ -7,6 +7,7 @@ import (
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/propagation"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	"go.opentelemetry.io/otel/trace"
@@ -15,7 +16,7 @@ import (
 func newTestTracingContext() (context.Context, *tracetest.InMemoryExporter) {
 	exporter := tracetest.NewInMemoryExporter()
 	provider := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
-	ctx := withProvider(context.Background(), provider, "test")
+	ctx := withProvider(context.Background(), provider, propagation.TraceContext{}, "test")
 	return ctx, exporter
 }
 


### PR DESCRIPTION
This introduces `trace.WithPropagator(...)` option so it's possible to configure propagators.

This is required for providers like Google Cloud which inject tracing context via `X-Cloud-Trace-Context` rather than W3C Trace Context.