### PR TITLE
feat: Mor flexible structure for fieds (closes #69)

### DIFF
--- a/log/README.md
+++ b/log/README.md
@@ -16,12 +16,24 @@ package main
 import (
         "context"
         "github.com/goadesign/clue/log"
-)       
+)
 
 func main() {
         ctx := log.Context(context.Background())
         log.Printf(ctx, "hello %s", "world")
         log.Print(ctx, log.KV{"hello", "world"})
+
+        log.Print(ctx,
+                log.KV{"example", "log.KV"},
+                log.KV{"order", "deterministic"},
+                log.KV{"backed_by", "slice"},
+        )
+
+        log.Print(ctx, log.Fields{
+                "example": "log.Fields",
+                "order": "random",
+                "backed_by": "map",
+        })
 }
 ```
 
@@ -31,6 +43,8 @@ formatter):
 ```
 time=2022-02-22T02:22:02Z level=info msg="hello world"
 time=2022-02-22T02:22:02Z level=info hello=world
+time=2022-02-22T02:22:02Z level=info example=log.KV order=deterministic backed_by=slice
+time=2022-02-22T02:22:02Z level=info order=random backed_by=map example=log.Fields
 ```
 
 A typical instantiation of the logger for a Goa service looks like this:

--- a/log/adapt.go
+++ b/log/adapt.go
@@ -113,6 +113,6 @@ func (l goaLogger) Log(keyvals ...interface{}) error {
 		k, v := keyvals[2*i], keyvals[2*i+1]
 		kvs[i] = KV{K: fmt.Sprint(k), V: v}
 	}
-	Print(l, kvs...)
+	Print(l, kvList(kvs))
 	return nil
 }

--- a/log/fields.go
+++ b/log/fields.go
@@ -1,0 +1,50 @@
+package log
+
+type (
+	// KV represents a key/value pair. Values must be strings, numbers,
+	// booleans, nil or a slice of these types.
+	KV struct {
+		K string
+		V interface{}
+	}
+
+	// Fielder is an interface that will return a slice of KV
+	Fielder interface {
+		LogFields() []KV
+	}
+
+	// Fields allows to quickly define fields for cases where you are OK with
+	// non-deterministic order of the fields
+	Fields map[string]interface{}
+
+	kvList []KV
+)
+
+func (kv KV) LogFields() []KV {
+	return []KV{kv}
+}
+
+func (f Fields) LogFields() []KV {
+	fields := make([]KV, 0, len(f))
+	for k, v := range f {
+		fields = append(fields, KV{k, v})
+	}
+	return fields
+}
+
+func (kvs kvList) merge(fielders []Fielder) kvList {
+	for _, fielder := range fielders {
+		switch fielder := fielder.(type) {
+		case KV:
+			// Avoid unnecessary allocation the slice from KV.LogFields
+			kvs = append(kvs, fielder)
+		default:
+			kvs = append(kvs, fielder.LogFields()...)
+		}
+	}
+	return kvs
+}
+
+func (kvs kvList) LogFields() []KV {
+	return kvs
+}

--- a/log/format_test.go
+++ b/log/format_test.go
@@ -128,7 +128,7 @@ func TestFormat(t *testing.T) {
 
 	cases := []struct {
 		name    string
-		logfn   func(ctx context.Context, keyvals ...KV)
+		logfn   func(ctx context.Context, keyvals ...Fielder)
 		format  FormatFunc
 		keyVals []KV
 		want    string
@@ -201,7 +201,7 @@ func TestFormat(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			var buf bytes.Buffer
 			ctx := Context(context.Background(), WithOutput(&buf), WithFormat(tc.format), WithDebug())
-			tc.logfn(ctx, tc.keyVals...)
+			tc.logfn(ctx, kvList(tc.keyVals))
 			got := buf.String()
 			if got != tc.want {
 				t.Errorf("got %s, want %s", got, tc.want)
@@ -211,7 +211,7 @@ func TestFormat(t *testing.T) {
 
 	errorCases := []struct {
 		name    string
-		logfn   func(ctx context.Context, err error, keyvals ...KV)
+		logfn   func(ctx context.Context, err error, keyvals ...Fielder)
 		format  FormatFunc
 		keyVals []KV
 		want    string
@@ -242,7 +242,7 @@ func TestFormat(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			var buf bytes.Buffer
 			ctx := Context(context.Background(), WithOutput(&buf), WithFormat(tc.format), WithDebug())
-			tc.logfn(ctx, errors.New("error"), tc.keyVals...)
+			tc.logfn(ctx, errors.New("error"), kvList(tc.keyVals))
 			got := buf.String()
 			if got != tc.want {
 				t.Errorf("got %s, want %s", got, tc.want)

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -287,7 +287,7 @@ func TestStructuredLogging(t *testing.T) {
 	}
 
 	// Key-value pairs are logged.
-	Info(ctx, []KV{{"key1", "val1"}, {"key2", "val2"}}...)
+	Info(ctx, KV{"key1", "val1"}, KV{"key2", "val2"})
 	if len(entries(ctx)) != 2 {
 		t.Fatalf("got %d buffered entries, want 2", len(entries(ctx)))
 	}
@@ -477,7 +477,7 @@ func TestMaxSize(t *testing.T) {
 			}
 
 			ctx := Context(context.Background(), WithOutput(&buf), WithMaxSize(maxsize), WithFormat(format))
-			Print(ctx, c.keyvals...)
+			Print(ctx, kvList(c.keyvals))
 
 			if buf.Len() != c.expected {
 				t.Errorf("got %d (%q), want %d", buf.Len(), buf.String(), c.expected)

--- a/log/options.go
+++ b/log/options.go
@@ -29,7 +29,7 @@ type (
 		debug            bool
 		w                io.Writer
 		format           FormatFunc
-		keyvals          []KV
+		keyvals          kvList
 		kvfuncs          []func(context.Context) []KV
 		maxsize          int
 	}


### PR DESCRIPTION
Implementing what we discussed in #69.

It's almost backwards compatible.

It will be a breaking change when people do:
```go
log.Print(ctx, keyvals...)
```

The reason being `keyvals` of type `[]log.KV` is different from `[]log.Fielder`.