### PR TITLE
feat(log): basic customization of keys and formatters (closes #72)

### DIFF
--- a/log/format.go
+++ b/log/format.go
@@ -20,6 +20,10 @@ func init() {
 	epoch = time.Now()
 }
 
+// TimestampFormatLayout is used to set the layout for our TimestampKey
+// (default "time") values.  Default format is time.RFC3339.
+var TimestampFormatLayout = time.RFC3339
+
 // FormatText is the default log formatter when not running in a terminal, it
 // prints entries using the logfmt format:
 //
@@ -28,11 +32,14 @@ func init() {
 // Where TIME is the UTC timestamp in RFC3339 format, SEVERITY is one of
 // "debug", "info" or "error", and KEY=VAL are the entry key/value pairs.
 // Values are quoted and escaped according to the logfmt specification.
+//
+// Output can be customised with log.TimestampKey, log.TimestampFormatLayout,
+// and log.SeverityKey.
 func FormatText(e *Entry) []byte {
 	var b bytes.Buffer
 	enc := logfmt.NewEncoder(&b)
-	enc.EncodeKeyval("time", e.Time.Format(time.RFC3339))
-	enc.EncodeKeyval("level", e.Severity)
+	enc.EncodeKeyval(TimestampKey, e.Time.Format(TimestampFormatLayout))
+	enc.EncodeKeyval(SeverityKey, e.Severity)
 	for _, kv := range e.KeyVals {
 		// Make logfmt format slices
 		v := kv.V
@@ -61,11 +68,18 @@ func FormatText(e *Entry) []byte {
 //
 // note: the implementation avoids using reflection (and thus the json package)
 // for efficiency.
+//
+// Output can be customised with log.TimestampKey, log.TimestampFormatLayout,
+// and log.SeverityKey.
 func FormatJSON(e *Entry) []byte {
 	var b bytes.Buffer
-	b.WriteString(`{"time":"`)
-	b.WriteString(e.Time.Format(time.RFC3339))
-	b.WriteString(`","level":"`)
+	b.WriteString(`{"`)
+	b.WriteString(TimestampKey)
+	b.WriteString(`":"`)
+	b.WriteString(e.Time.Format(TimestampFormatLayout))
+	b.WriteString(`","`)
+	b.WriteString(SeverityKey)
+	b.WriteString(`":"`)
 	b.WriteString(e.Severity.String())
 	b.WriteByte('"')
 	if len(e.KeyVals) > 0 {

--- a/log/grpc.go
+++ b/log/grpc.go
@@ -20,7 +20,7 @@ func UnaryServerInterceptor(logCtx context.Context) grpc.UnaryServerInterceptor 
 	) (interface{}, error) {
 		ctx = WithContext(ctx, logCtx)
 		if reqID := ctx.Value(middleware.RequestIDKey); reqID != nil {
-			ctx = With(ctx, KV{"requestID", reqID})
+			ctx = With(ctx, KV{RequestIDKey, reqID})
 		}
 		return handler(ctx, req)
 	}
@@ -39,7 +39,7 @@ func StreamServerInterceptor(logCtx context.Context) grpc.StreamServerIntercepto
 	) error {
 		ctx := WithContext(stream.Context(), logCtx)
 		if reqID := ctx.Value(middleware.RequestIDKey); reqID != nil {
-			ctx = With(ctx, KV{"requestID", reqID})
+			ctx = With(ctx, KV{RequestIDKey, reqID})
 		}
 		return handler(srv, &streamWithContext{stream, ctx})
 	}

--- a/log/http.go
+++ b/log/http.go
@@ -15,7 +15,7 @@ func HTTP(logCtx context.Context) func(http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 			ctx := WithContext(req.Context(), logCtx)
 			if requestID := req.Context().Value(middleware.RequestIDKey); requestID != nil {
-				ctx = With(ctx, KV{"requestID", requestID})
+				ctx = With(ctx, KV{RequestIDKey, requestID})
 			}
 			h.ServeHTTP(w, req.WithContext(ctx))
 		})

--- a/log/keys.go
+++ b/log/keys.go
@@ -1,0 +1,10 @@
+package log
+
+var (
+	TraceIDKey      = "traceID"
+	RequestIDKey    = "requestID"
+	MessageKey      = "msg"
+	ErrorMessageKey = "err"
+	TimestampKey    = "time"
+	SeverityKey     = "level"
+)

--- a/log/log.go
+++ b/log/log.go
@@ -60,10 +60,10 @@ func Debug(ctx context.Context, keyvals ...KV) {
 	log(ctx, SeverityDebug, true, keyvals)
 }
 
-// Debugf sets the key "msg" and calls Debug. Arguments are handled in the
-// manner of fmt.Printf.
+// Debugf sets the key MessageKey (default "msg") and calls Debug. Arguments
+// are handled in the manner of fmt.Printf.
 func Debugf(ctx context.Context, format string, v ...interface{}) {
-	Debug(ctx, KV{"msg", fmt.Sprintf(format, v...)})
+	Debug(ctx, KV{MessageKey, fmt.Sprintf(format, v...)})
 }
 
 // Print writes the key/value pairs to the log output ignoring buffering.
@@ -71,10 +71,10 @@ func Print(ctx context.Context, keyvals ...KV) {
 	log(ctx, SeverityInfo, false, keyvals)
 }
 
-// Printf sets the key "msg" and calls Print. Arguments are handled in the
-// manner of fmt.Printf.
+// Printf sets the key MessageKey (default "msg") and calls Print. Arguments
+// are handled in the manner of fmt.Printf.
 func Printf(ctx context.Context, format string, v ...interface{}) {
-	Print(ctx, KV{"msg", fmt.Sprintf(format, v...)})
+	Print(ctx, KV{MessageKey, fmt.Sprintf(format, v...)})
 }
 
 // Info writes the key/value pairs to the log buffer or output if buffering is
@@ -83,27 +83,27 @@ func Info(ctx context.Context, keyvals ...KV) {
 	log(ctx, SeverityInfo, true, keyvals)
 }
 
-// Infof sets the key "msg" and calls Info. Arguments are handled in the manner
-// of fmt.Printf.
+// Infof sets the key MessageKey (default "msg") and calls Info. Arguments are
+// handled in the manner of fmt.Printf.
 func Infof(ctx context.Context, format string, v ...interface{}) {
-	Info(ctx, KV{"msg", fmt.Sprintf(format, v...)})
+	Info(ctx, KV{MessageKey, fmt.Sprintf(format, v...)})
 }
 
 // Error flushes the log buffer and disables buffering if not already disabled.
-// Error then sets the "err" key with the given error and writes the key/value
-// pairs to the log output.
+// Error then sets the ErrorMessageKey (default "err") key with the given error
+// and writes the key/value pairs to the log output.
 func Error(ctx context.Context, err error, keyvals ...KV) {
 	FlushAndDisableBuffering(ctx)
 	if err != nil {
-		keyvals = append(keyvals, KV{"err", err.Error()})
+		keyvals = append(keyvals, KV{ErrorMessageKey, err.Error()})
 	}
 	log(ctx, SeverityError, true, keyvals)
 }
 
-// Errorf sets the key "msg" and calls Error. Arguments are handled in the
-// manner of fmt.Printf.
+// Errorf sets the key MessageKey (default "msg") and calls Error. Arguments
+// are handled in the manner of fmt.Printf.
 func Errorf(ctx context.Context, err error, format string, v ...interface{}) {
-	Error(ctx, err, KV{"msg", fmt.Sprintf(format, v...)})
+	Error(ctx, err, KV{MessageKey, fmt.Sprintf(format, v...)})
 }
 
 // Fatal is equivalent to Error followed by a call to os.Exit(1)
@@ -114,7 +114,7 @@ func Fatal(ctx context.Context, err error, keyvals ...KV) {
 
 // Fatalf is equivalent to Errorf followed by a call to os.Exit(1)
 func Fatalf(ctx context.Context, err error, format string, v ...interface{}) {
-	Fatal(ctx, err, KV{"msg", fmt.Sprintf(format, v...)})
+	Fatal(ctx, err, KV{MessageKey, fmt.Sprintf(format, v...)})
 }
 
 // With creates a copy of the given log context and appends the given key/value

--- a/trace/grpc.go
+++ b/trace/grpc.go
@@ -106,7 +106,7 @@ func initTracingContextGRPCUnary(traceCtx context.Context, h grpc.UnaryHandler) 
 	return func(ctx context.Context, req interface{}) (interface{}, error) {
 		if IsTraced(ctx) {
 			ctx = withTracing(traceCtx, ctx)
-			log.Debug(ctx, log.KV{"traceID", trace.SpanFromContext(ctx).SpanContext().TraceID()})
+			log.Debug(ctx, log.KV{log.TraceIDKey, trace.SpanFromContext(ctx).SpanContext().TraceID()})
 		}
 		return h(ctx, req)
 	}
@@ -133,7 +133,7 @@ func initTracingContextGRPCStream(traceCtx context.Context, h grpc.StreamHandler
 		if IsTraced(stream.Context()) {
 			ctx := withTracing(traceCtx, stream.Context())
 			log.Debug(stream.Context(),
-				log.KV{"traceID", trace.SpanFromContext(stream.Context()).SpanContext().TraceID()})
+				log.KV{log.TraceIDKey, trace.SpanFromContext(stream.Context()).SpanContext().TraceID()})
 			stream = &streamWithContext{ctx: ctx, ServerStream: stream}
 		}
 		return h(srv, stream)

--- a/trace/http.go
+++ b/trace/http.go
@@ -86,7 +86,7 @@ func initTracingContext(traceCtx context.Context, h http.Handler) http.Handler {
 		if IsTraced(ctx) {
 			req = req.WithContext(withTracing(traceCtx, ctx))
 			log.Debug(ctx,
-				log.KV{"traceID", trace.SpanFromContext(ctx).SpanContext().TraceID()})
+				log.KV{log.TraceIDKey, trace.SpanFromContext(ctx).SpanContext().TraceID()})
 		}
 		h.ServeHTTP(w, req)
 	})


### PR DESCRIPTION
This avoids hardcoding key names, using exported variables instead so
people can tweak the names to match their schema.

It also allows basic customization of the pre-existing formatters, where
you can customize the timestamp and severity keys, and define the
timestamp format layout.

This is useful to keep people from copying the formatters for such basic
customization, which would keep us from delivering future fixes and
improvements to their formatter.