### PR TITLE
feat(trace): Extensibility of the tracer

### DIFF
--- a/trace/context.go
+++ b/trace/context.go
@@ -57,10 +57,14 @@ func Context(ctx context.Context, svc string, opts ...TraceOption) (context.Cont
 		return nil, errors.New("missing exporter")
 	}
 
-	res := resource.NewWithAttributes(semconv.SchemaURL, semconv.ServiceNameKey.String(svc))
+	res := options.resource
+	if res == nil {
+		res = resource.NewWithAttributes(semconv.SchemaURL, semconv.ServiceNameKey.String(svc))
+	}
+
 	rootSampler := adaptiveSampler(options.maxSamplingRate, options.sampleSize)
 	provider := sdktrace.NewTracerProvider(
-		sdktrace.WithSampler(sdktrace.ParentBased(rootSampler)),
+		sdktrace.WithSampler(sdktrace.ParentBased(rootSampler, options.parentSamplerOptions...)),
 		sdktrace.WithResource(res),
 		sdktrace.WithBatcher(options.exporter),
 	)

--- a/trace/options.go
+++ b/trace/options.go
@@ -5,17 +5,20 @@ import (
 
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
 	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"google.golang.org/grpc"
 )
 
 type (
 	options struct {
-		maxSamplingRate int
-		sampleSize      int
-		exporter        sdktrace.SpanExporter
-		propagator      propagation.TextMapPropagator
-		disabled        bool
+		maxSamplingRate      int
+		sampleSize           int
+		exporter             sdktrace.SpanExporter
+		propagator           propagation.TextMapPropagator
+		parentSamplerOptions []sdktrace.ParentBasedSamplerOption
+		resource             *resource.Resource
+		disabled             bool
 	}
 
 	// TraceOption is a function that configures a provider.
@@ -60,6 +63,22 @@ func WithDisabled() TraceOption {
 func WithExporter(exporter sdktrace.SpanExporter) TraceOption {
 	return func(ctx context.Context, opts *options) error {
 		opts.exporter = exporter
+		return nil
+	}
+}
+
+// WithParentSamplerOptions to set the options for sdktrace.ParentBased sampler.
+func WithParentSamplerOptions(samplerOptions ...sdktrace.ParentBasedSamplerOption) TraceOption {
+	return func(ctx context.Context, opts *options) error {
+		opts.parentSamplerOptions = samplerOptions
+		return nil
+	}
+}
+
+// WithResource sets the underlying opentelemetry resource.
+func WithResource(res *resource.Resource) TraceOption {
+	return func(ctx context.Context, opts *options) error {
+		opts.resource = res
 		return nil
 	}
 }


### PR DESCRIPTION
When using certain providers like Google Cloud, clue was falling short on being able to extend the tracing.

This adds a couple of further `TraceOption`s:
* **trace.WithResource**: to be able to run [custom detectors][detectors].
* **trace.WithParentSamplerOptions**: to be able to propagate whether a trace should be sampled. [Example][propagator].

[detectors]: https://pkg.go.dev/go.opentelemetry.io/contrib/detectors/gcp
[propagator]: https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/tree/main/propagator#differences-between-google-cloud-trace-and-w3c-trace-context