### PR TITLE
StartTrace and ContinueRemoteTrace

### DIFF
--- a/example/weather/README.md
+++ b/example/weather/README.md
@@ -44,7 +44,7 @@ To analyze traces:
 * Retrieve the front service trace ID from its logs, for example:
 
 ```
-front      | DEBG[0003] svc=front requestID=aZtVOM7L traceID=fcb9bb474db0b095923b110b7c1cdcab
+front      | DEBG[0003] svc=front request-id=aZtVOM7L trace-id=fcb9bb474db0b095923b110b7c1cdcab
 ```
 
 * Open the Grafana dashboard running on

--- a/log/grpc_test.go
+++ b/log/grpc_test.go
@@ -34,7 +34,7 @@ func TestUnaryServerInterceptor(t *testing.T) {
 	expected := fmt.Sprintf("{%s,%s,%s%q,%s,%s}\n",
 		`"time":"2022-01-09T20:29:45Z"`,
 		`"level":"info"`,
-		`"requestID":`,
+		`"request-id":`,
 		*f.S,
 		`"key1":"value1"`,
 		`"key2":"value2"`)
@@ -73,7 +73,7 @@ func TestStreamServerTrace(t *testing.T) {
 	expected := fmt.Sprintf("{%s,%s,%s%q,%s,%s}\n",
 		`"time":"2022-01-09T20:29:45Z"`,
 		`"level":"info"`,
-		`"requestID":`,
+		`"request-id":`,
 		reqID,
 		`"key1":"value1"`,
 		`"key2":"value2"`)

--- a/log/http_test.go
+++ b/log/http_test.go
@@ -34,7 +34,7 @@ func TestHTTP(t *testing.T) {
 	expected := fmt.Sprintf("{%s,%s,%s,%s,%s}\n",
 		`"time":"2022-01-09T20:29:45Z"`,
 		`"level":"info"`,
-		`"requestID":"request-id"`,
+		`"request-id":"request-id"`,
 		`"key1":"value1"`,
 		`"key2":"value2"`)
 

--- a/log/keys.go
+++ b/log/keys.go
@@ -1,8 +1,9 @@
 package log
 
 var (
-	TraceIDKey      = "traceID"
-	RequestIDKey    = "requestID"
+	TraceIDKey      = "trace-id"
+	SpanIDKey       = "span-id"
+	RequestIDKey    = "request-id"
 	MessageKey      = "msg"
 	ErrorMessageKey = "err"
 	TimestampKey    = "time"

--- a/trace/grpc.go
+++ b/trace/grpc.go
@@ -6,7 +6,6 @@ import (
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
-	"goa.design/clue/log"
 	"goa.design/goa/v3/middleware"
 	"google.golang.org/grpc"
 )
@@ -99,11 +98,7 @@ func addRequestIDGRPCUnary(h grpc.UnaryHandler) grpc.UnaryHandler {
 func initTracingContextGRPCUnary(traceCtx context.Context, h grpc.UnaryHandler) grpc.UnaryHandler {
 	return func(ctx context.Context, req interface{}) (interface{}, error) {
 		if IsTraced(ctx) {
-			ctx := withTracing(traceCtx, ctx)
-			sctx := trace.SpanFromContext(ctx).SpanContext()
-			log.Debug(ctx,
-				log.KV{K: log.TraceIDKey, V: sctx.TraceID()},
-				log.KV{K: log.SpanIDKey, V: sctx.SpanID()})
+			ctx = withTracing(traceCtx, ctx)
 		}
 		return h(ctx, req)
 	}
@@ -129,10 +124,6 @@ func initTracingContextGRPCStream(traceCtx context.Context, h grpc.StreamHandler
 	return func(srv interface{}, stream grpc.ServerStream) error {
 		if IsTraced(stream.Context()) {
 			ctx := withTracing(traceCtx, stream.Context())
-			sctx := trace.SpanFromContext(ctx).SpanContext()
-			log.Debug(ctx,
-				log.KV{K: log.TraceIDKey, V: sctx.TraceID()},
-				log.KV{K: log.SpanIDKey, V: sctx.SpanID()})
 			stream = &streamWithContext{ctx: ctx, ServerStream: stream}
 		}
 		return h(srv, stream)

--- a/trace/grpc.go
+++ b/trace/grpc.go
@@ -11,9 +11,8 @@ import (
 	"google.golang.org/grpc"
 )
 
-// UnaryServerInterceptor returns an OpenTelemetry UnaryServerInterceptor configured
-// to export traces to AWS X-Ray. It panics if the context has not been
-// initialized with Context.
+// UnaryServerInterceptor returns an OpenTelemetry UnaryServerInterceptor. It
+// panics if the context has not been initialized with Context.
 func UnaryServerInterceptor(traceCtx context.Context) grpc.UnaryServerInterceptor {
 	state := traceCtx.Value(stateKey)
 	if state == nil {
@@ -29,15 +28,13 @@ func UnaryServerInterceptor(traceCtx context.Context) grpc.UnaryServerIntercepto
 		handler = addRequestIDGRPCUnary(handler)
 		ui := otelgrpc.UnaryServerInterceptor(
 			otelgrpc.WithTracerProvider(state.(*stateBag).provider),
-			otelgrpc.WithPropagators(state.(*stateBag).propagator),
-		)
+			otelgrpc.WithPropagators(state.(*stateBag).propagator))
 		return ui(ctx, req, info, handler)
 	}
 }
 
-// StreamServerInterceptor returns an OpenTelemetry StreamServerInterceptor configured
-// to export traces to AWS X-Ray. It panics if the context has not been
-// initialized with Context.
+// StreamServerInterceptor returns an OpenTelemetry StreamServerInterceptor. It
+// panics if the context has not been initialized with Context.
 func StreamServerInterceptor(traceCtx context.Context) grpc.StreamServerInterceptor {
 	state := traceCtx.Value(stateKey)
 	if state == nil {
@@ -59,9 +56,8 @@ func StreamServerInterceptor(traceCtx context.Context) grpc.StreamServerIntercep
 	}
 }
 
-// UnaryClientInterceptor returns an OpenTelemetry UnaryClientInterceptor configured
-// to export traces to AWS X-Ray. It panics if the context has not been
-// initialized with Context.
+// UnaryClientInterceptor returns an OpenTelemetry UnaryClientInterceptor. It
+// panics if the context has not been initialized with Context.
 func UnaryClientInterceptor(traceCtx context.Context) grpc.UnaryClientInterceptor {
 	state := traceCtx.Value(stateKey)
 	if state == nil {
@@ -72,9 +68,8 @@ func UnaryClientInterceptor(traceCtx context.Context) grpc.UnaryClientIntercepto
 		otelgrpc.WithPropagators(state.(*stateBag).propagator))
 }
 
-// StreamClientInterceptor returns an OpenTelemetry StreamClientInterceptor configured
-// to export traces to AWS X-Ray. It panics if the context has not been
-// initialized with Context.
+// StreamClientInterceptor returns an OpenTelemetry StreamClientInterceptor. It
+// panics if the context has not been initialized with Context.
 func StreamClientInterceptor(traceCtx context.Context) grpc.StreamClientInterceptor {
 	state := traceCtx.Value(stateKey)
 	if state == nil {
@@ -105,7 +100,6 @@ func initTracingContextGRPCUnary(traceCtx context.Context, h grpc.UnaryHandler) 
 	return func(ctx context.Context, req interface{}) (interface{}, error) {
 		if IsTraced(ctx) {
 			ctx = withTracing(traceCtx, ctx)
-			log.Debug(ctx, log.KV{log.TraceIDKey, trace.SpanFromContext(ctx).SpanContext().TraceID()})
 		}
 		return h(ctx, req)
 	}

--- a/trace/http.go
+++ b/trace/http.go
@@ -7,7 +7,6 @@ import (
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
-	"goa.design/clue/log"
 	"goa.design/goa/v3/middleware"
 )
 
@@ -83,10 +82,6 @@ func initTracingContext(traceCtx context.Context, h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		if IsTraced(req.Context()) {
 			ctx := withTracing(traceCtx, req.Context())
-			sctx := trace.SpanFromContext(ctx).SpanContext()
-			log.Debug(ctx,
-				log.KV{K: log.TraceIDKey, V: sctx.TraceID()},
-				log.KV{K: log.SpanIDKey, V: sctx.SpanID()})
 			req = req.WithContext(ctx)
 		}
 		h.ServeHTTP(w, req)

--- a/trace/http.go
+++ b/trace/http.go
@@ -81,11 +81,13 @@ func addRequestIDHTTP(h http.Handler) http.Handler {
 // context.
 func initTracingContext(traceCtx context.Context, h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		ctx := req.Context()
-		if IsTraced(ctx) {
-			req = req.WithContext(withTracing(traceCtx, ctx))
+		if IsTraced(req.Context()) {
+			ctx := withTracing(traceCtx, req.Context())
+			sctx := trace.SpanFromContext(ctx).SpanContext()
 			log.Debug(ctx,
-				log.KV{log.TraceIDKey, trace.SpanFromContext(ctx).SpanContext().TraceID()})
+				log.KV{K: log.TraceIDKey, V: sctx.TraceID()},
+				log.KV{K: log.SpanIDKey, V: sctx.SpanID()})
+			req = req.WithContext(ctx)
 		}
 		h.ServeHTTP(w, req)
 	})

--- a/trace/log.go
+++ b/trace/log.go
@@ -6,14 +6,6 @@ import (
 	"goa.design/clue/log"
 )
 
-var (
-	// TraceIDLogKey is the key used to log the trace ID.
-	TraceIDLogKey = "traceID"
-
-	// SpanIDLogKey is the key used to log the span ID.
-	SpanIDLogKey = "spanID"
-)
-
 // Log is a log key/value pair generator function that can be used to log trace
 // and span IDs. Example:
 //
@@ -23,10 +15,10 @@ var (
 //    Output: traceID=<trace-id> spanID=<span-id> message
 func Log(ctx context.Context) (kvs []log.KV) {
 	if id := TraceID(ctx); id != "" {
-		kvs = append(kvs, log.KV{K: TraceIDLogKey, V: id})
+		kvs = append(kvs, log.KV{K: log.TraceIDKey, V: id})
 	}
 	if id := SpanID(ctx); id != "" {
-		kvs = append(kvs, log.KV{K: SpanIDLogKey, V: id})
+		kvs = append(kvs, log.KV{K: log.SpanIDKey, V: id})
 	}
 	return
 }

--- a/trace/log_test.go
+++ b/trace/log_test.go
@@ -3,6 +3,8 @@ package trace
 import (
 	"context"
 	"testing"
+
+	"goa.design/clue/log"
 )
 
 func TestLog(t *testing.T) {
@@ -13,14 +15,14 @@ func TestLog(t *testing.T) {
 	if len(kvs) != 2 {
 		t.Fatalf("got %d kvs, expected 2", len(kvs))
 	}
-	if kvs[0].K != TraceIDLogKey {
-		t.Errorf("got kvs[0].K %q, expected %q", kvs[0].K, TraceIDLogKey)
+	if kvs[0].K != log.TraceIDKey {
+		t.Errorf("got kvs[0].K %q, expected %q", kvs[0].K, log.TraceIDKey)
 	}
 	if kvs[0].V != TraceID(ctx) {
 		t.Errorf("got kvs[0].V %q, expected %q", kvs[0].V, TraceID(ctx))
 	}
-	if kvs[1].K != SpanIDLogKey {
-		t.Errorf("got kvs[1].K %q, expected %q", kvs[1].K, SpanIDLogKey)
+	if kvs[1].K != log.SpanIDKey {
+		t.Errorf("got kvs[1].K %q, expected %q", kvs[1].K, log.SpanIDKey)
 	}
 	if kvs[1].V != SpanID(ctx) {
 		t.Errorf("got kvs[1].V %q, expected %q", kvs[1].V, SpanID(ctx))


### PR DESCRIPTION
This PR adds two new functions to the `trace` package that make it possible to initiate traces from code not running within a service:

* `StartTrace` creates a new client trace and initializes the context so that it gets propagated to remote services when requests are made using a tracing HTTP or gRPC client.
* `ContinueRemoteTrace` behaves similarly to `StartTrace` but accepts a parent trace ID as argument and creates a server side trace . This makes it possible to continue traces asynchronously (for example in an adapter reading traced messages from a queueing system).