### PR TITLE
Fix import paths in sample programs

### DIFF
--- a/log/README.md
+++ b/log/README.md
@@ -15,7 +15,7 @@ package main
 
 import (
         "context"
-        "github.com/goadesign/clue/log"
+        "goa.design/clue/log"
 )
 
 func main() {

--- a/metrics/README.md
+++ b/metrics/README.md
@@ -17,8 +17,8 @@ package main
 import (
         "context"
 
-        "github.com/goadesign/clue/metrics"
-        "github.com/goadesign/clue/log"
+        "goa.design/clue/metrics"
+        "goa.design/clue/log"
        	goahttp "goa.design/goa/v3/http"
 
        	"github.com/repo/services/svc"

--- a/trace/README.md
+++ b/trace/README.md
@@ -32,8 +32,8 @@ package main
 import (
        "context"
 
-       "github.com/goadesign/clue/log"
-       "github.com/goadesign/clue/trace"
+       "goa.design/clue/log"
+       "goa.design/clue/trace"
        	goahttp "goa.design/goa/v3/http"
 
        "github.com/repo/services/svc"


### PR DESCRIPTION
The module declares its path as `goa.design/clue`.