### PR TITLE
Create check specific contexts

### DIFF
--- a/health/checker.go
+++ b/health/checker.go
@@ -56,6 +56,9 @@ func (c *checker) Check(ctx context.Context) (*Health, bool) {
 	healthy := true
 	for _, dep := range c.deps {
 		res.Status[dep.Name()] = "OK"
+		// Note: need to create a new context for each dependency So that one
+		// dependency canceling the context will not affect the other checks.
+		ctx = log.With(ctx, log.KV{K: "dep", V: dep.Name()})
 		if err := dep.Ping(ctx); err != nil {
 			res.Status[dep.Name()] = "NOT OK"
 			healthy = false

--- a/health/checker.go
+++ b/health/checker.go
@@ -62,7 +62,7 @@ func (c *checker) Check(ctx context.Context) (*Health, bool) {
 		if err := dep.Ping(ctx); err != nil {
 			res.Status[dep.Name()] = "NOT OK"
 			healthy = false
-			log.Error(ctx, err, log.KV{K: "msg", V: "ping failed"}, log.KV{K: "target", V: dep.Name()})
+			log.Error(ctx, err, log.KV{K: "msg", V: "ping failed"})
 		}
 	}
 	return res, healthy

--- a/trace/grpc_test.go
+++ b/trace/grpc_test.go
@@ -160,6 +160,7 @@ func TestStreamClientTrace(t *testing.T) {
 	if err := stream.Send(&testsvc.Fields{}); err != nil {
 		t.Errorf("unexpected send error: %v", err)
 	}
+	stream.Recv()
 	cancel()
 	stop()
 	spans := exporter.GetSpans()


### PR DESCRIPTION
So that one check failing and canceling the context
does not affect the other checks.