### PR TITLE
Really create new contexts for checks

### DIFF
--- a/health/checker.go
+++ b/health/checker.go
@@ -58,8 +58,8 @@ func (c *checker) Check(ctx context.Context) (*Health, bool) {
 		res.Status[dep.Name()] = "OK"
 		// Note: need to create a new context for each dependency So that one
 		// dependency canceling the context will not affect the other checks.
-		ctx = log.With(ctx, log.KV{K: "dep", V: dep.Name()})
-		if err := dep.Ping(ctx); err != nil {
+		logCtx := log.With(context.Background(), log.KV{K: "dep", V: dep.Name()})
+		if err := dep.Ping(logCtx); err != nil {
 			res.Status[dep.Name()] = "NOT OK"
 			healthy = false
 			log.Error(ctx, err, log.KV{K: "msg", V: "ping failed"})


### PR DESCRIPTION
So that if one service fails the health check other checks
don't get affected.