### PR TITLE
Use http.RoundTripper for client side logging

### DIFF
--- a/example/weather/services/forecaster/cmd/forecaster/main.go
+++ b/example/weather/services/forecaster/cmd/forecaster/main.go
@@ -70,8 +70,8 @@ func main() {
 	ctx = metrics.Context(ctx, genforecaster.ServiceName)
 
 	// 4. Create clients
-	c := &http.Client{Transport: trace.Client(ctx, http.DefaultTransport)}
-	wc := weathergov.New(log.Client(c))
+	c := &http.Client{Transport: log.Client(trace.Client(ctx, http.DefaultTransport))}
+	wc := weathergov.New(c)
 
 	// 5. Create service & endpoints
 	svc := forecaster.New(wc)

--- a/example/weather/services/locator/cmd/locator/main.go
+++ b/example/weather/services/locator/cmd/locator/main.go
@@ -70,8 +70,8 @@ func main() {
 	ctx = metrics.Context(ctx, genlocator.ServiceName)
 
 	// 4. Create clients
-	c := &http.Client{Transport: trace.Client(ctx, http.DefaultTransport)}
-	ipc := ipapi.New(log.Client(c))
+	c := &http.Client{Transport: log.Client(trace.Client(ctx, http.DefaultTransport))}
+	ipc := ipapi.New(c)
 
 	// 5. Create service & endpoints
 	svc := locator.New(ipc)


### PR DESCRIPTION
Instead of introducing custom Doer interface.
This makes it possible to configure a standard HTTP client