### PR TITLE
Add debug package

### DIFF
--- a/debug/debug.go
+++ b/debug/debug.go
@@ -1,0 +1,121 @@
+package debug
+
+import (
+	"context"
+	"net/http"
+	"net/http/pprof"
+
+	goa "goa.design/goa/v3/pkg"
+
+	"goa.design/clue/log"
+)
+
+// Muxer is the HTTP mux interface used by the debug package.
+type Muxer interface {
+	http.Handler
+	Handle(pattern string, handler http.Handler)
+	HandleFunc(pattern string, handler func(http.ResponseWriter, *http.Request))
+}
+
+var (
+	// wantDebugEnabled is true if debug logs should be enabled.
+	wantDebugEnabled bool
+
+	// debugEnabled is true if debug logs are currently enabled.
+	debugEnabled bool
+
+	// pprofEnabled is true if pprof handlers are enabled.
+	pprofEnabled bool
+)
+
+// MountDebugLogEnabler mounts an endpoint under the given prefix and returns a
+// HTTP middleware that manages debug logs. The endpoint accepts a single query
+// parameter "enable". If the parameter is set to "on" then debug logs are
+// enabled for requests made to handlers returned by the middleware. If the
+// parameter is set to "off" then debug logs are disabled.
+func MountDebugLogEnabler(prefix string, mux Muxer) func(http.Handler) http.Handler {
+	mux.Handle(prefix, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Query().Get("enable") {
+		case "on":
+			wantDebugEnabled = true
+		case "off":
+			wantDebugEnabled = false
+		}
+	}))
+	return func(next http.Handler) http.Handler {
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if wantDebugEnabled && !debugEnabled {
+				r = r.WithContext(log.Context(r.Context(), log.WithDebug()))
+				debugEnabled = true
+			} else if !wantDebugEnabled && debugEnabled {
+				r = r.WithContext(log.Context(r.Context(), log.WithNoDebug()))
+				debugEnabled = false
+			}
+			next.ServeHTTP(w, r)
+		})
+		return handler
+	}
+}
+
+// MountPprofHandlers mounts pprof handlers under /debug/pprof/. The list of
+// mounted handlers is:
+//
+//	/debug/pprof/
+//	/debug/pprof/allocs
+//	/debug/pprof/block
+//	/debug/pprof/cmdline
+//	/debug/pprof/goroutine
+//	/debug/pprof/heap
+//	/debug/pprof/mutex
+//	/debug/pprof/profile
+//	/debug/pprof/symbol
+//	/debug/pprof/threadcreate
+//	/debug/pprof/trace
+//
+// See the pprof package documentation for more information.
+//
+// Note: do not call this function on production servers accessible to the
+// public!  It exposes sensitive information about the server.
+func MountPprofHandlers(mux Muxer) {
+	mux.HandleFunc("/debug/pprof/", pprof.Index)
+	mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+	mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+}
+
+// LogPayloads returns a Goa endpoint middleware that logs request payloads and
+// response results using debug log entries.
+//
+// Note: this middleware marshals the request and response data using the
+// standard JSON marshaller. It only marshals if debug logs are enabled.
+func LogPayloads(opts ...LogPayloadsOption) func(goa.Endpoint) goa.Endpoint {
+	return func(next goa.Endpoint) goa.Endpoint {
+		options := defaultOptions()
+		for _, opt := range opts {
+			if opt != nil {
+				opt(options)
+			}
+		}
+		return func(ctx context.Context, req interface{}) (interface{}, error) {
+			if !log.DebugEnabled(ctx) {
+				return next(ctx, req)
+			}
+			reqs := options.format(ctx, req)
+			if len(reqs) > options.maxsize {
+				reqs = reqs[:options.maxsize]
+			}
+			log.Debug(ctx, log.KV{K: "payload", V: reqs})
+			res, err := next(ctx, req)
+			if err != nil {
+				return nil, err
+			}
+			ress := options.format(ctx, res)
+			if len(ress) > options.maxsize {
+				ress = ress[:options.maxsize]
+			}
+			log.Debug(ctx, log.KV{K: "result", V: ress})
+			return res, nil
+		}
+	}
+}

--- a/debug/debug_test.go
+++ b/debug/debug_test.go
@@ -1,0 +1,216 @@
+package debug
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"goa.design/clue/internal/testsvc"
+	"goa.design/clue/internal/testsvc/gen/test"
+	"goa.design/clue/log"
+)
+
+func TestMountDebugLogEnabler(t *testing.T) {
+	mux := http.NewServeMux()
+	var handler http.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		log.Info(r.Context(), log.KV{K: "test", V: "info"})
+		log.Debug(r.Context(), log.KV{K: "test", V: "debug"})
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("OK"))
+	})
+	handler = MountDebugLogEnabler("/debug", mux)(handler)
+	var buf bytes.Buffer
+	ctx := log.Context(context.Background(), log.WithOutput(&buf), log.WithFormat(logKeyValsOnly))
+	log.FlushAndDisableBuffering(ctx)
+	handler = log.HTTP(ctx)(handler)
+	mux.Handle("/", handler)
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	steps := []struct {
+		name         string
+		enable       bool
+		disable      bool
+		expectedLogs string
+	}{
+		{"default", false, false, "test=info "},
+		{"enable debug", true, false, "test=info test=debug "},
+		{"disable debug", false, true, "test=info "},
+	}
+
+	for _, c := range steps {
+		if c.enable {
+			status, resp := makeRequest(t, ts.URL+"/debug?enable=on")
+			if status != http.StatusOK {
+				t.Errorf("%s: got status %d, expected %d", c.name, status, http.StatusOK)
+			}
+			if resp != "" {
+				t.Errorf("%s: got body %q, expected %q", c.name, resp, "")
+			}
+		}
+		if c.disable {
+			status, resp := makeRequest(t, ts.URL+"/debug?enable=off")
+			if status != http.StatusOK {
+				t.Errorf("%s: got status %d, expected %d", c.name, status, http.StatusOK)
+			}
+			if resp != "" {
+				t.Errorf("%s: got body %q, expected %q", c.name, resp, "")
+			}
+		}
+		buf.Reset()
+
+		status, resp := makeRequest(t, ts.URL)
+		if status != http.StatusOK {
+			t.Errorf("%s: got status %d, expected %d", c.name, status, http.StatusOK)
+		}
+		if resp != "OK" {
+			t.Errorf("%s: got body %q, expected %q", c.name, resp, "OK")
+		}
+		if buf.String() != c.expectedLogs {
+			t.Errorf("%s: got logs %q, expected %q", c.name, buf.String(), c.expectedLogs)
+		}
+	}
+}
+
+func TestMountPprofHandlers(t *testing.T) {
+	mux := http.NewServeMux()
+	MountPprofHandlers(mux)
+	var handler http.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("OK"))
+	})
+	mux.Handle("/", handler)
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	status, resp := makeRequest(t, ts.URL)
+	if status != http.StatusOK {
+		t.Errorf("got status %d, expected %d", status, http.StatusOK)
+	}
+	if resp != "OK" {
+		t.Errorf("got body %q, expected %q", resp, "OK")
+	}
+
+	paths := []string{
+		"/debug/pprof/",
+		"/debug/pprof/allocs",
+		"/debug/pprof/block",
+		"/debug/pprof/cmdline",
+		"/debug/pprof/goroutine",
+		"/debug/pprof/heap",
+		"/debug/pprof/mutex",
+		// "/debug/pprof/profile?seconds=1", # Takes too long to run on each test
+		"/debug/pprof/symbol",
+		"/debug/pprof/threadcreate",
+		// "/debug/pprof/trace", # Takes too long to run on each test
+	}
+	for _, path := range paths {
+		status, resp = makeRequest(t, ts.URL+path)
+		if status != http.StatusOK {
+			t.Errorf("got status %d, expected %d", status, http.StatusOK)
+		}
+		if resp == "" {
+			t.Errorf("got body %q, expected non-empty", resp)
+		}
+	}
+}
+
+func TestDebugPayloads(t *testing.T) {
+	svc := testsvc.Service{}
+	var buf bytes.Buffer
+	vals, vali := "test", 1
+	payload := &test.Fields{S: &vals, I: &vali}
+	testErr := errors.New("test error")
+	newLogContext := func() context.Context {
+		return log.Context(context.Background(), log.WithOutput(&buf), log.WithFormat(logKeyValsOnly))
+	}
+	newDebugLogContext := func() context.Context {
+		return log.Context(newLogContext(), log.WithDebug())
+	}
+	formatTest := func(_ context.Context, a interface{}) string {
+		return "test"
+	}
+
+	cases := []struct {
+		name         string
+		ctx          context.Context
+		option       LogPayloadsOption
+		methErr      error
+		expectedLogs string
+		expectedErr  string
+	}{
+		{"no debug", newLogContext(), nil, nil, "", ""},
+		{"debug", newDebugLogContext(), nil, nil, `payload={"S":"test","I":1} result={"S":"test","I":1} `, ""},
+		{"error", newLogContext(), nil, testErr, "", "test error"},
+		{"debug error", newDebugLogContext(), nil, testErr, `payload={"S":"test","I":1} `, "test error"},
+		{"maxsize", newDebugLogContext(), WithMaxSize(1), nil, `payload={ result={ `, ""},
+		{"format", newDebugLogContext(), WithFormat(formatTest), nil, `payload=test result=test `, ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			buf.Reset()
+			svc.HTTPFunc = func(ctx context.Context, f *testsvc.Fields) (*testsvc.Fields, error) {
+				if c.expectedErr != "" {
+					return nil, errors.New(c.expectedErr)
+				}
+				return f, nil
+			}
+			endpoint := test.NewHTTPMethodEndpoint(&svc)
+			endpoint = LogPayloads(c.option)(endpoint)
+			res, err := endpoint(c.ctx, payload)
+			if buf.String() != c.expectedLogs {
+				t.Errorf("got unexpected logs %q", buf.String())
+			}
+			if err != nil {
+				if err.Error() != c.expectedErr {
+					t.Errorf("got unexpected error %v", err)
+				}
+				return
+			}
+			if c.expectedErr != "" {
+				t.Fatalf("expected error %q", c.expectedErr)
+			}
+			if res == nil {
+				t.Fatal("got nil response")
+			}
+			if *(res.(*test.Fields)) != *payload {
+				t.Errorf("got unexpected response %v", res)
+			}
+		})
+	}
+}
+
+func logKeyValsOnly(e *log.Entry) []byte {
+	var buf bytes.Buffer
+	for _, kv := range e.KeyVals {
+		buf.WriteString(kv.K)
+		buf.WriteString("=")
+		buf.WriteString(fmt.Sprintf("%v", kv.V))
+		buf.WriteString(" ")
+	}
+	return buf.Bytes()
+}
+
+func makeRequest(t *testing.T, url string) (int, string) {
+	req, _ := http.NewRequest("GET", url, nil)
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("failed to make request %q: %s", url, err)
+	}
+	defer res.Body.Close()
+	buf := new(bytes.Buffer)
+	buf.ReadFrom(res.Body)
+	return res.StatusCode, buf.String()
+}

--- a/debug/goa.go
+++ b/debug/goa.go
@@ -1,0 +1,36 @@
+package debug
+
+import (
+	"net/http"
+
+	goahttp "goa.design/goa/v3/http"
+)
+
+// muxAdapter is a debug.Muxer adapter for goahttp.Muxer.
+type muxAdapter struct {
+	muxer goahttp.Muxer
+}
+
+// HTTP methods supported by the adapter.
+var httpMethods = []string{"GET", "HEAD", "POST", "PUT", "PATCH", "DELETE", "CONNECT", "OPTIONS", "TRACE"}
+
+// Adapt returns a debug.Muxer adapter for the given goahttp.Muxer.
+func Adapt(m goahttp.Muxer) Muxer {
+	return muxAdapter{muxer: m}
+}
+
+func (m muxAdapter) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	m.muxer.ServeHTTP(w, r)
+}
+
+func (m muxAdapter) Handle(path string, handler http.Handler) {
+	for _, method := range httpMethods {
+		m.muxer.Handle(method, path, handler.ServeHTTP)
+	}
+}
+
+func (m muxAdapter) HandleFunc(path string, handler func(http.ResponseWriter, *http.Request)) {
+	for _, method := range httpMethods {
+		m.muxer.Handle(method, path, handler)
+	}
+}

--- a/debug/goa_test.go
+++ b/debug/goa_test.go
@@ -1,0 +1,41 @@
+package debug
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	goahttp "goa.design/goa/v3/http"
+)
+
+func TestAdapt(t *testing.T) {
+	mux := goahttp.NewMuxer()
+	adapted := Adapt(mux)
+	adapted.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("OK"))
+	})
+	adapted.Handle("/foo", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("FOO"))
+	}))
+	req := &http.Request{Method: "GET", URL: &url.URL{Path: "/"}}
+	w := httptest.NewRecorder()
+	adapted.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("got status %d, expected %d", w.Code, http.StatusOK)
+	}
+	if w.Body.String() != "OK" {
+		t.Errorf("got body %q, expected %q", w.Body.String(), "OK")
+	}
+	req = &http.Request{Method: "GET", URL: &url.URL{Path: "/foo"}}
+	w = httptest.NewRecorder()
+	adapted.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("got status %d, expected %d", w.Code, http.StatusOK)
+	}
+	if w.Body.String() != "FOO" {
+		t.Errorf("got body %q, expected %q", w.Body.String(), "FOO")
+	}
+}

--- a/debug/grpc.go
+++ b/debug/grpc.go
@@ -1,0 +1,60 @@
+package debug
+
+import (
+	"context"
+
+	"google.golang.org/grpc"
+
+	"goa.design/clue/log"
+)
+
+// UnaryServerInterceptor return an interceptor that manages whether debug log
+// entries are written.
+func UnaryServerInterceptor() grpc.UnaryServerInterceptor {
+	return func(
+		ctx context.Context,
+		req interface{},
+		info *grpc.UnaryServerInfo,
+		handler grpc.UnaryHandler,
+	) (interface{}, error) {
+		if wantDebugEnabled && !debugEnabled {
+			ctx = log.Context(ctx, log.WithDebug())
+			debugEnabled = true
+		} else if !wantDebugEnabled && debugEnabled {
+			ctx = log.Context(ctx, log.WithNoDebug())
+			debugEnabled = false
+		}
+		return handler(ctx, req)
+	}
+}
+
+// StreamServerInterceptor returns a stream interceptor that manages whether
+// debug log entries are written. Note: a change in the debug setting is
+// effective only for the next stream request.
+func StreamServerInterceptor() grpc.StreamServerInterceptor {
+	return func(
+		srv interface{},
+		stream grpc.ServerStream,
+		info *grpc.StreamServerInfo,
+		handler grpc.StreamHandler,
+	) error {
+		ctx := stream.Context()
+		if wantDebugEnabled && !debugEnabled {
+			ctx = log.Context(ctx, log.WithDebug())
+			debugEnabled = true
+		} else if !wantDebugEnabled && debugEnabled {
+			ctx = log.Context(ctx, log.WithNoDebug())
+			debugEnabled = false
+		}
+		return handler(srv, &streamWithContext{stream, ctx})
+	}
+}
+
+type streamWithContext struct {
+	grpc.ServerStream
+	ctx context.Context
+}
+
+func (s *streamWithContext) Context() context.Context {
+	return s.ctx
+}

--- a/debug/grpc_test.go
+++ b/debug/grpc_test.go
@@ -1,0 +1,99 @@
+package debug
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"google.golang.org/grpc"
+
+	"goa.design/clue/internal/testsvc"
+	"goa.design/clue/log"
+)
+
+func TestUnaryServerInterceptor(t *testing.T) {
+	var buf bytes.Buffer
+	ctx := log.Context(context.Background(), log.WithOutput(&buf), log.WithFormat(logKeyValsOnly))
+	cli, stop := testsvc.SetupGRPC(t,
+		testsvc.WithServerOptions(grpc.ChainUnaryInterceptor(log.UnaryServerInterceptor(ctx), UnaryServerInterceptor())),
+		testsvc.WithUnaryFunc(logUnaryMethod))
+	defer stop()
+	_, err := cli.GRPCMethod(context.Background(), nil)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if buf.String() != "" {
+		t.Errorf("unexpected log %q", buf.String())
+	}
+	wantDebugEnabled = true
+	_, err = cli.GRPCMethod(context.Background(), nil)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if buf.String() != "debug=message " {
+		t.Errorf("expected log %q, got %q", "debug=message ", buf.String())
+	}
+	wantDebugEnabled = false
+	buf.Reset()
+	_, err = cli.GRPCMethod(context.Background(), nil)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if buf.String() != "" {
+		t.Errorf("unexpected log %q", buf.String())
+	}
+}
+
+func TestStreamServerInterceptor(t *testing.T) {
+	var buf bytes.Buffer
+	ctx := log.Context(context.Background(), log.WithOutput(&buf), log.WithFormat(logKeyValsOnly))
+	cli, stop := testsvc.SetupGRPC(t,
+		testsvc.WithServerOptions(grpc.ChainStreamInterceptor(log.StreamServerInterceptor(ctx), StreamServerInterceptor())),
+		testsvc.WithStreamFunc(echoMethod))
+	defer stop()
+	steps := []struct {
+		name            string
+		enableDebugLogs bool
+		expectedLogs    string
+	}{
+		{"no debug logs", false, ""},
+		{"debug logs", true, "debug=message "},
+		{"revert to no debug logs", false, ""},
+	}
+	for _, step := range steps {
+		wantDebugEnabled = step.enableDebugLogs
+		stream, err := cli.GRPCStream(context.Background())
+		if err != nil {
+			t.Errorf("%s: unexpected error: %v", step.name, err)
+		}
+		defer stream.Close()
+		if err = stream.Send(&testsvc.Fields{}); err != nil {
+			t.Errorf("%s: unexpected send error: %v", step.name, err)
+		}
+		if _, err = stream.Recv(); err != nil {
+			t.Errorf("%s: unexpected recv error: %v", step.name, err)
+		}
+		if buf.String() != step.expectedLogs {
+			t.Errorf("%s: unexpected log %q", step.name, buf.String())
+		}
+		buf.Reset()
+	}
+}
+
+func logUnaryMethod(ctx context.Context, _ *testsvc.Fields) (*testsvc.Fields, error) {
+	log.Debug(ctx, log.KV{K: "debug", V: "message"})
+	return &testsvc.Fields{}, nil
+}
+
+func echoMethod(ctx context.Context, stream testsvc.Stream) (err error) {
+	for {
+		_, err := stream.Recv()
+		if err != nil {
+			return err
+		}
+		log.Debug(ctx, log.KV{K: "debug", V: "message"})
+		if err = stream.Send(&testsvc.Fields{}); err != nil {
+			return err
+		}
+	}
+}

--- a/debug/options.go
+++ b/debug/options.go
@@ -1,0 +1,57 @@
+package debug
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+type (
+	// LogPayloadsOption is a function that applies a configuration option
+	// to the LogPayloads middleware.
+	LogPayloadsOption func(*options)
+
+	// FormatFunc is used to format the logged value for payloads and
+	// results.
+	FormatFunc func(context.Context, interface{}) string
+
+	options struct {
+		maxsize int // maximum number of bytes in a single log message or value
+		format  FormatFunc
+	}
+)
+
+// DefaultMaxSize is the default maximum size for a logged request or result
+// value in bytes.
+const DefaultMaxSize = 1024
+
+// WithFormat sets the log format.
+func WithFormat(fn FormatFunc) LogPayloadsOption {
+	return func(o *options) {
+		o.format = fn
+	}
+}
+
+// WithMaxSize sets the maximum size of a single log message or value.
+func WithMaxSize(n int) LogPayloadsOption {
+	return func(o *options) {
+		o.maxsize = n
+	}
+}
+
+// FormatJSON returns a function that formats the given value as JSON.
+func FormatJSON(ctx context.Context, v interface{}) string {
+	js, err := json.Marshal(v)
+	if err != nil {
+		return fmt.Sprintf("<invalid: %s>", err)
+	}
+	return string(js)
+}
+
+// defaultOptions returns a new options struct with default values.
+func defaultOptions() *options {
+	return &options{
+		format:  FormatJSON,
+		maxsize: DefaultMaxSize,
+	}
+}

--- a/debug/options_test.go
+++ b/debug/options_test.go
@@ -1,0 +1,46 @@
+package debug
+
+import (
+	"context"
+	"fmt"
+	"testing"
+)
+
+func TestDefaultOptions(t *testing.T) {
+	opts := defaultOptions()
+	if fmt.Sprintf("%p", opts.format) != fmt.Sprintf("%p", FormatJSON) {
+		t.Errorf("got format %p, expected %p", opts.format, FormatJSON)
+	}
+	if opts.maxsize != DefaultMaxSize {
+		t.Errorf("got maxsize %d, expected %d", opts.maxsize, DefaultMaxSize)
+	}
+}
+
+func TestWithFormat(t *testing.T) {
+	opts := defaultOptions()
+	WithFormat(FormatJSON)(opts)
+	if fmt.Sprintf("%p", opts.format) != fmt.Sprintf("%p", FormatJSON) {
+		t.Errorf("got format %p, expected %p", opts.format, FormatJSON)
+	}
+}
+
+func TestWithMaxSize(t *testing.T) {
+	opts := defaultOptions()
+	WithMaxSize(10)(opts)
+	if opts.maxsize != 10 {
+		t.Errorf("got maxsize %d, expected 10", opts.maxsize)
+	}
+}
+
+func TestFormatJSON(t *testing.T) {
+	ctx := context.Background()
+	js := FormatJSON(ctx, map[string]string{"foo": "bar"})
+	if js != `{"foo":"bar"}` {
+		t.Errorf("got %q, expected %q", js, `{"foo":"bar"}`)
+	}
+	js = FormatJSON(ctx, make(chan int))
+	if js != `<invalid: json: unsupported type: chan int>` {
+		t.Errorf("got %q, expected %q", js, `<invalid: json: unsupported type: chan int>`)
+	}
+
+}

--- a/example/weather/Procfile
+++ b/example/weather/Procfile
@@ -1,3 +1,3 @@
-forecaster: bin/forecaster -debug
-locator: bin/locator -debug
-front: bin/front -debug
+forecaster: bin/forecaster
+locator: bin/locator
+front: bin/front

--- a/example/weather/services/locator/cmd/locator/main.go
+++ b/example/weather/services/locator/cmd/locator/main.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	grpcmiddleware "github.com/grpc-ecosystem/go-grpc-middleware"
+	"goa.design/clue/debug"
 	"goa.design/clue/health"
 	"goa.design/clue/log"
 	"goa.design/clue/metrics"
@@ -34,7 +35,7 @@ func main() {
 		grpcaddr  = flag.String("grpc-addr", ":8082", "gRPC listen address")
 		httpaddr  = flag.String("http-addr", ":8083", "HTTP listen address (health checks and metrics)")
 		agentaddr = flag.String("agent-addr", ":4317", "Grafana agent listen address")
-		debug     = flag.Bool("debug", false, "Enable debug logs")
+		debugf    = flag.Bool("debug", false, "Enable debug logs")
 	)
 	flag.Parse()
 
@@ -45,7 +46,7 @@ func main() {
 	}
 	ctx := log.Context(context.Background(), log.WithFormat(format), log.WithFunc(trace.Log))
 	ctx = log.With(ctx, log.KV{"svc", genlocator.ServiceName})
-	if *debug {
+	if *debugf {
 		ctx = log.Context(ctx, log.WithDebug())
 		log.Debugf(ctx, "debug logs enabled")
 	}
@@ -76,6 +77,7 @@ func main() {
 	// 5. Create service & endpoints
 	svc := locator.New(ipc)
 	endpoints := genlocator.NewEndpoints(svc)
+	endpoints.Use(debug.LogPayloads())
 	endpoints.Use(log.Endpoint)
 
 	// 6. Create transport
@@ -84,6 +86,7 @@ func main() {
 		grpcmiddleware.WithUnaryServerChain(
 			goagrpcmiddleware.UnaryRequestID(),
 			log.UnaryServerInterceptor(ctx),
+			debug.UnaryServerInterceptor(),
 			goagrpcmiddleware.UnaryServerLogContext(log.AsGoaMiddlewareLogger),
 			trace.UnaryServerInterceptor(ctx),
 			metrics.UnaryServerInterceptor(ctx),
@@ -96,12 +99,15 @@ func main() {
 		}
 	}
 
-	// 7. Start health check
+	// 7. Setup health check, metrics and debug endpoints
 	check := log.HTTP(ctx)(health.Handler(health.NewChecker(ipc)))
-	http.Handle("/healthz", check)
-	http.Handle("/livez", check)
-	http.Handle("/metrics", metrics.Handler(ctx))
-	httpsvr := &http.Server{Addr: *httpaddr}
+	mux := http.NewServeMux()
+	debug.MountPprofHandlers(mux)
+	mux.Handle("/healthz", check)
+	mux.Handle("/livez", check)
+	mux.Handle("/metrics", metrics.Handler(ctx))
+	handler := debug.MountDebugLogEnabler("/debug", mux)(mux)
+	httpsvr := &http.Server{Addr: *httpaddr, Handler: handler}
 
 	// 8. Start gRPC and HTTP servers
 	errc := make(chan error)

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	goa.design/goa/v3 v3.10.2
 	goa.design/model v1.7.9
 	golang.org/x/term v0.4.0
-	google.golang.org/grpc v1.51.0
+	google.golang.org/grpc v1.52.0
 	google.golang.org/protobuf v1.28.1
 )
 
@@ -49,10 +49,10 @@ require (
 	go.opentelemetry.io/otel/metric v0.34.0 // indirect
 	go.opentelemetry.io/proto/otlp v0.19.0 // indirect
 	golang.org/x/mod v0.7.0 // indirect
-	golang.org/x/net v0.4.0 // indirect
+	golang.org/x/net v0.5.0 // indirect
 	golang.org/x/sys v0.4.0 // indirect
-	golang.org/x/text v0.5.0 // indirect
-	golang.org/x/tools v0.4.0 // indirect
-	google.golang.org/genproto v0.0.0-20221227171554-f9683d7f8bef // indirect
+	golang.org/x/text v0.6.0 // indirect
+	golang.org/x/tools v0.5.0 // indirect
+	google.golang.org/genproto v0.0.0-20230112194545-e10362b5ecf9 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -323,8 +323,8 @@ golang.org/x/net v0.0.0-20200707034311-ab3426394381/go.mod h1:/O7V0waA8r7cgGh81R
 golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
-golang.org/x/net v0.4.0 h1:Q5QPcMlvfxFTAPV0+07Xz/MpK9NTXu2VDUuy0FeMfaU=
-golang.org/x/net v0.4.0/go.mod h1:MBQ8lrhLObU/6UmLb4fmbmk5OcyYmqtbGd/9yIeKjEE=
+golang.org/x/net v0.5.0 h1:GyT4nK/YDHSqa1c4753ouYCDajOYKTja9Xb/OHtgvSw=
+golang.org/x/net v0.5.0/go.mod h1:DivGGAXEgPSlEBzxGzZI+ZLohi+xUj054jfeKui00ws=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -383,8 +383,8 @@ golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.5/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
-golang.org/x/text v0.5.0 h1:OLmvp0KP+FVG99Ct/qFiL/Fhk4zp4QQnZ7b2U+5piUM=
-golang.org/x/text v0.5.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
+golang.org/x/text v0.6.0 h1:3XmdazWV+ubf7QgHSTWeykHOci5oeekaGJBLkrkaw4k=
+golang.org/x/text v0.6.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
@@ -430,8 +430,8 @@ golang.org/x/tools v0.0.0-20200729194436-6467de6f59a7/go.mod h1:njjCfa9FT2d7l9Bc
 golang.org/x/tools v0.0.0-20200804011535-6c149bb5ef0d/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20200825202427-b303f430e36d/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
-golang.org/x/tools v0.4.0 h1:7mTAgkunk3fr4GAloyyCasadO6h9zSsQZbwvcaIciV4=
-golang.org/x/tools v0.4.0/go.mod h1:UE5sM2OK9E/d67R0ANs2xJizIymRP5gJU295PvKXxjQ=
+golang.org/x/tools v0.5.0 h1:+bSpV5HIeWkuvgaMfI3UmKRThoTA5ODJTUd8T17NO+4=
+golang.org/x/tools v0.5.0/go.mod h1:N+Kgy78s5I24c24dU8OfWNEotWjutIs8SnJvn5IDq+k=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
@@ -491,8 +491,8 @@ google.golang.org/genproto v0.0.0-20200729003335-053ba62fc06f/go.mod h1:FWY/as6D
 google.golang.org/genproto v0.0.0-20200804131852-c06518451d9c/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20200825200019-8632dd797987/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20211118181313-81c1377c94b1/go.mod h1:5CzLGKJ67TSI2B9POpiiyGha0AjJvZIUgRMt1dSmuhc=
-google.golang.org/genproto v0.0.0-20221227171554-f9683d7f8bef h1:uQ2vjV/sHTsWSqdKeLqmwitzgvjMl7o4IdtHwUDXSJY=
-google.golang.org/genproto v0.0.0-20221227171554-f9683d7f8bef/go.mod h1:RGgjbofJ8xD9Sq1VVhDM1Vok1vRONV+rg+CjzG4SZKM=
+google.golang.org/genproto v0.0.0-20230112194545-e10362b5ecf9 h1:ru6tJGasqJpgjM4q3Qq2fS3FKQ6CPPSRqgolUVBc994=
+google.golang.org/genproto v0.0.0-20230112194545-e10362b5ecf9/go.mod h1:RGgjbofJ8xD9Sq1VVhDM1Vok1vRONV+rg+CjzG4SZKM=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiqXj38=
 google.golang.org/grpc v1.21.1/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=
@@ -509,8 +509,8 @@ google.golang.org/grpc v1.33.1/go.mod h1:fr5YgcSWrqhRRxogOsw7RzIpsmvOZ6IcH4kBYTp
 google.golang.org/grpc v1.36.0/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAGRRjU=
 google.golang.org/grpc v1.40.0/go.mod h1:ogyxbiOoUXAkP+4+xa6PZSE9DZgIHtSpzjDTB9KAK34=
 google.golang.org/grpc v1.42.0/go.mod h1:k+4IHHFw41K8+bbowsex27ge2rCb65oeWqe4jJ590SU=
-google.golang.org/grpc v1.51.0 h1:E1eGv1FTqoLIdnBCZufiSHgKjlqG6fKFf6pPWtMTh8U=
-google.golang.org/grpc v1.51.0/go.mod h1:wgNDFcnuBGmxLKI/qn4T+m5BtEBYXJPvibbUPsAIPww=
+google.golang.org/grpc v1.52.0 h1:kd48UiU7EHsV4rnLyOJRuP/Il/UHE7gdDAQ+SZI7nZk=
+google.golang.org/grpc v1.52.0/go.mod h1:pu6fVzoFb+NBYNAvQL08ic+lvB2IojljRYuun5vorUY=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=

--- a/internal/testsvc/grpc_testing.go
+++ b/internal/testsvc/grpc_testing.go
@@ -48,7 +48,7 @@ func SetupGRPC(t *testing.T, opts ...GRPCOption) (c GRPClient, stop func()) {
 	}
 
 	// Create test gRPC server
-	s := svc{grpcfn: options.grpcfn, streamfn: options.streamfn}
+	s := Service{GRPCFunc: options.grpcfn, StreamFunc: options.streamfn}
 	endpoints := test.NewEndpoints(&s)
 	svr := server.New(endpoints, nil, nil)
 	server := grpc.NewServer(options.serverOptions...)

--- a/internal/testsvc/http_testing.go
+++ b/internal/testsvc/http_testing.go
@@ -45,7 +45,7 @@ func SetupHTTP(t *testing.T, opts ...HTTPOption) (c HTTPClient, stop func()) {
 	}
 
 	// Create test HTTP server
-	svc := &svc{httpfn: options.fn}
+	svc := &Service{HTTPFunc: options.fn}
 	endpoints := test.NewEndpoints(svc)
 	mux := goahttp.NewMuxer()
 	svr := server.New(endpoints, mux, goahttp.RequestDecoder, goahttp.ResponseEncoder, nil, nil)

--- a/internal/testsvc/service.go
+++ b/internal/testsvc/service.go
@@ -18,10 +18,10 @@ type (
 		Close() error
 	}
 
-	svc struct {
-		httpfn   UnaryFunc
-		grpcfn   UnaryFunc
-		streamfn StreamFunc
+	Service struct {
+		HTTPFunc   UnaryFunc
+		GRPCFunc   UnaryFunc
+		StreamFunc StreamFunc
 	}
 
 	adapter struct {
@@ -29,8 +29,8 @@ type (
 	}
 )
 
-func (s *svc) HTTPMethod(ctx context.Context, req *test.Fields) (res *test.Fields, err error) {
-	if s.httpfn == nil {
+func (s *Service) HTTPMethod(ctx context.Context, req *test.Fields) (res *test.Fields, err error) {
+	if s.HTTPFunc == nil {
 		return
 	}
 
@@ -40,7 +40,7 @@ func (s *svc) HTTPMethod(ctx context.Context, req *test.Fields) (res *test.Field
 		*r = Fields(*req)
 	}
 	var resp *Fields
-	resp, err = s.httpfn(ctx, r)
+	resp, err = s.HTTPFunc(ctx, r)
 	if resp != nil {
 		res = &test.Fields{}
 		*res = test.Fields(*resp)
@@ -48,8 +48,8 @@ func (s *svc) HTTPMethod(ctx context.Context, req *test.Fields) (res *test.Field
 	return
 }
 
-func (s *svc) GrpcMethod(ctx context.Context, req *test.Fields) (res *test.Fields, err error) {
-	if s.grpcfn == nil {
+func (s *Service) GrpcMethod(ctx context.Context, req *test.Fields) (res *test.Fields, err error) {
+	if s.GRPCFunc == nil {
 		return
 	}
 
@@ -59,7 +59,7 @@ func (s *svc) GrpcMethod(ctx context.Context, req *test.Fields) (res *test.Field
 		*r = Fields(*req)
 	}
 	var resp *Fields
-	resp, err = s.grpcfn(ctx, r)
+	resp, err = s.GRPCFunc(ctx, r)
 	if resp != nil {
 		res = &test.Fields{}
 		*res = test.Fields(*resp)
@@ -67,9 +67,9 @@ func (s *svc) GrpcMethod(ctx context.Context, req *test.Fields) (res *test.Field
 	return
 }
 
-func (s *svc) GrpcStream(ctx context.Context, stream test.GrpcStreamServerStream) (err error) {
-	if s.streamfn != nil {
-		return s.streamfn(ctx, adapter{stream})
+func (s *Service) GrpcStream(ctx context.Context, stream test.GrpcStreamServerStream) (err error) {
+	if s.StreamFunc != nil {
+		return s.StreamFunc(ctx, adapter{stream})
 	}
 	return nil
 }

--- a/log/context.go
+++ b/log/context.go
@@ -44,3 +44,15 @@ func MustContainLogger(logCtx context.Context) {
 		panic("provided a context without a logger. Use log.Context")
 	}
 }
+
+// DebugEnabled returns true if the given context has debug logging enabled.
+func DebugEnabled(ctx context.Context) bool {
+	v := ctx.Value(ctxLogger)
+	if v == nil {
+		return false
+	}
+	l := v.(*logger)
+	l.lock.Lock()
+	defer l.lock.Unlock()
+	return l.options.debug
+}

--- a/log/context_test.go
+++ b/log/context_test.go
@@ -1,0 +1,17 @@
+package log
+
+import (
+	"context"
+	"testing"
+)
+
+func TestDebugEnabled(t *testing.T) {
+	ctx := Context(context.Background())
+	if DebugEnabled(ctx) {
+		t.Errorf("expected debug logs to be disabled")
+	}
+	ctx = Context(ctx, WithDebug())
+	if !DebugEnabled(ctx) {
+		t.Errorf("expected debug logs to be enabled")
+	}
+}

--- a/log/options.go
+++ b/log/options.go
@@ -61,6 +61,13 @@ func WithDebug() LogOption {
 	}
 }
 
+// WithNoDebug disables debug logging.
+func WithNoDebug() LogOption {
+	return func(o *options) {
+		o.debug = false
+	}
+}
+
 // WithOutput sets the log output.
 func WithOutput(w io.Writer) LogOption {
 	return func(o *options) {

--- a/log/options_test.go
+++ b/log/options_test.go
@@ -48,6 +48,15 @@ func TestWithDebug(t *testing.T) {
 	}
 }
 
+func TestWithNoDebug(t *testing.T) {
+	opts := defaultOptions()
+	WithDebug()(opts)
+	WithNoDebug()(opts)
+	if opts.debug {
+		t.Errorf("expected debug to be disabled")
+	}
+}
+
 func TestWithOutput(t *testing.T) {
 	opts := defaultOptions()
 	w := io.Discard


### PR DESCRIPTION
 The debug package provides the following functionality:
* MountDebugLogEnabler mounts a handler on a HTTP mux to turn on or off debug logs.
* MountPprofHandlers mounts the pprof handlers on a HTTP mux.
* LogPayloads is a Goa endpoint middleware that logs request and result payloads.