### PR TITLE
Support embedded interfaces in cmg

### DIFF
--- a/mock/cmd/cmg/pkg/generate/_tests/extensive/aliased/imported.go
+++ b/mock/cmd/cmg/pkg/generate/_tests/extensive/aliased/imported.go
@@ -2,4 +2,8 @@ package imported
 
 type (
 	Type byte
+
+	Interface interface {
+		Imported(Type) Type
+	}
 )

--- a/mock/cmd/cmg/pkg/generate/_tests/extensive/extensive.go
+++ b/mock/cmd/cmg/pkg/generate/_tests/extensive/extensive.go
@@ -38,6 +38,13 @@ type (
 		NamedTypes(Struct, Array, io.Reader, imported.Type, goa.Endpoint, Generic[uint, string, Struct, Array]) (Struct, Array, io.Reader, imported.Type, goa.Endpoint, Generic[uint, string, Struct, Array])
 		FuncNamedTypes(func(Struct, Array, io.Reader, imported.Type, goa.Endpoint, Generic[uint, string, Struct, Array])) func(Struct, Array, io.Reader, imported.Type, goa.Endpoint, Generic[uint, string, Struct, Array])
 		VariableConflicts(f, m uint)
+
+		Embedded
+		imported.Interface
+	}
+
+	Embedded interface {
+		Embedded(int8) int8
 	}
 
 	Generic[K comparable, V ~int | bool | string, X, Y any] interface {

--- a/mock/cmd/cmg/pkg/generate/_tests/extensive/mocks/extensive.go
+++ b/mock/cmd/cmg/pkg/generate/_tests/extensive/mocks/extensive.go
@@ -34,6 +34,15 @@ type (
 	ExtensiveNamedTypesFunc        func(p0 extensive.Struct, p1 extensive.Array, p2 io.Reader, p3 imported.Type, p4 goa.Endpoint, p5 extensive.Generic[uint, string, extensive.Struct, extensive.Array]) (extensive.Struct, extensive.Array, io.Reader, imported.Type, goa.Endpoint, extensive.Generic[uint, string, extensive.Struct, extensive.Array])
 	ExtensiveFuncNamedTypesFunc    func(p0 func(extensive.Struct, extensive.Array, io.Reader, imported.Type, goa.Endpoint, extensive.Generic[uint, string, extensive.Struct, extensive.Array])) func(extensive.Struct, extensive.Array, io.Reader, imported.Type, goa.Endpoint, extensive.Generic[uint, string, extensive.Struct, extensive.Array])
 	ExtensiveVariableConflictsFunc func(f, m uint)
+	ExtensiveEmbeddedFunc          func(p0 int8) int8
+	ExtensiveImportedFunc          func(p0 imported.Type) imported.Type
+
+	Embedded struct {
+		m *mock.Mock
+		t *testing.T
+	}
+
+	EmbeddedEmbeddedFunc func(p0 int8) int8
 
 	Generic[K comparable, V ~int | bool | string, X, Y any] struct {
 		m *mock.Mock
@@ -239,7 +248,70 @@ func (m1 *Extensive) VariableConflicts(f, m uint) {
 	m1.t.Error("unexpected VariableConflicts call")
 }
 
+func (m *Extensive) AddEmbedded(f ExtensiveEmbeddedFunc) {
+	m.m.Add("Embedded", f)
+}
+
+func (m *Extensive) SetEmbedded(f ExtensiveEmbeddedFunc) {
+	m.m.Set("Embedded", f)
+}
+
+func (m *Extensive) Embedded(p0 int8) int8 {
+	if f := m.m.Next("Embedded"); f != nil {
+		return f.(ExtensiveEmbeddedFunc)(p0)
+	}
+	m.t.Helper()
+	m.t.Error("unexpected Embedded call")
+	return 0
+}
+
+func (m *Extensive) AddImported(f ExtensiveImportedFunc) {
+	m.m.Add("Imported", f)
+}
+
+func (m *Extensive) SetImported(f ExtensiveImportedFunc) {
+	m.m.Set("Imported", f)
+}
+
+func (m *Extensive) Imported(p0 imported.Type) imported.Type {
+	if f := m.m.Next("Imported"); f != nil {
+		return f.(ExtensiveImportedFunc)(p0)
+	}
+	m.t.Helper()
+	m.t.Error("unexpected Imported call")
+	return 0
+}
+
 func (m *Extensive) HasMore() bool {
+	return m.m.HasMore()
+}
+
+func NewEmbedded(t *testing.T) *Embedded {
+	var (
+		m                    = &Embedded{mock.New(), t}
+		_ extensive.Embedded = m
+	)
+	return m
+}
+
+func (m *Embedded) AddEmbedded(f EmbeddedEmbeddedFunc) {
+	m.m.Add("Embedded", f)
+}
+
+func (m *Embedded) SetEmbedded(f EmbeddedEmbeddedFunc) {
+	m.m.Set("Embedded", f)
+}
+
+func (m *Embedded) Embedded(p0 int8) int8 {
+	if f := m.m.Next("Embedded"); f != nil {
+		return f.(EmbeddedEmbeddedFunc)(p0)
+	}
+	m.t.Helper()
+	m.t.Error("unexpected Embedded call")
+	return 0
+}
+
+func (m *Embedded) HasMore() bool {
 	return m.m.HasMore()
 }
 

--- a/mock/cmd/cmg/pkg/parse/_tests/doer/doer.go
+++ b/mock/cmd/cmg/pkg/parse/_tests/doer/doer.go
@@ -1,8 +1,20 @@
 package doer
 
+import (
+	"example.com/a/b/external"
+)
+
 type (
 	Doer interface {
 		Do(a, b int, c float64) (d, e int, err error)
+	}
+
+	EmbeddedDoer interface {
+		Doer
+	}
+
+	ExternalEmbeddedDoer interface {
+		external.Doer
 	}
 
 	doer interface { //nolint:unused

--- a/mock/cmd/cmg/pkg/parse/_tests/external/doer.go
+++ b/mock/cmd/cmg/pkg/parse/_tests/external/doer.go
@@ -1,0 +1,7 @@
+package external
+
+type (
+	Doer interface {
+		Do(a, b int, c float64) (d, e int, err error)
+	}
+)

--- a/mock/cmd/cmg/pkg/parse/method_test.go
+++ b/mock/cmd/cmg/pkg/parse/method_test.go
@@ -2,6 +2,7 @@ package parse
 
 import (
 	"go/ast"
+	"go/types"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -11,11 +12,16 @@ import (
 func TestMethod_Name(t *testing.T) {
 	cases := []struct {
 		Name, Expected string
-		Ident          *ast.Ident
+		Method         Method
 	}{
 		{
-			Name:     "success",
-			Ident:    ast.NewIdent("Do"),
+			Name:     "AST success",
+			Method:   newASTMethod(nil, ast.NewIdent("Do"), nil, false),
+			Expected: "Do",
+		},
+		{
+			Name:     "types success",
+			Method:   newTypesMethod(types.NewFunc(0, nil, "Do", &types.Signature{})),
 			Expected: "Do",
 		},
 	}
@@ -25,65 +31,36 @@ func TestMethod_Name(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			t.Parallel()
 
-			method := newMethod(nil, tc.Ident, nil, false)
-			name := method.Name()
+			name := tc.Method.Name()
 			assert.Equal(t, tc.Expected, name)
 		})
 	}
 }
 
-func TestMethod_(t *testing.T) {
-	p := &packages.Package{}
-	cases := []struct {
-		Name     string
-		FuncType *ast.FuncType
-		Expected []Value
-	}{
-		{
-			Name: "success",
-			FuncType: &ast.FuncType{Results: &ast.FieldList{List: []*ast.Field{
-				{
-					Names: []*ast.Ident{ast.NewIdent("a"), ast.NewIdent("b")},
-					Type:  ast.NewIdent("int"),
-				},
-				{
-					Names: []*ast.Ident{ast.NewIdent("err")},
-					Type:  ast.NewIdent("error"),
-				},
-			}}},
-			Expected: []Value{
-				newValue(p, ast.NewIdent("a"), ast.NewIdent("int")),
-				newValue(p, ast.NewIdent("b"), ast.NewIdent("int")),
-				newValue(p, ast.NewIdent("err"), ast.NewIdent("error")),
-			},
-		},
-	}
-
-	for _, tc := range cases {
-		tc := tc
-		t.Run(tc.Name, func(t *testing.T) {
-			t.Parallel()
-
-			method := newMethod(p, nil, tc.FuncType, false)
-			results := method.Results()
-			assert.Equal(t, tc.Expected, results)
-		})
-	}
-}
 func TestMethod_IsExported(t *testing.T) {
 	cases := []struct {
 		Name     string
-		Ident    *ast.Ident
+		Method   Method
 		Expected bool
 	}{
 		{
-			Name:     "exported",
-			Ident:    ast.NewIdent("Do"),
+			Name:     "AST exported",
+			Method:   newASTMethod(nil, ast.NewIdent("Do"), nil, false),
 			Expected: true,
 		},
 		{
-			Name:     "not exported",
-			Ident:    ast.NewIdent("do"),
+			Name:     "AST not exported",
+			Method:   newASTMethod(nil, ast.NewIdent("do"), nil, false),
+			Expected: false,
+		},
+		{
+			Name:     "types exported",
+			Method:   newTypesMethod(types.NewFunc(0, nil, "Do", &types.Signature{})),
+			Expected: true,
+		},
+		{
+			Name:     "types not exported",
+			Method:   newTypesMethod(types.NewFunc(0, nil, "do", &types.Signature{})),
 			Expected: false,
 		},
 	}
@@ -93,23 +70,27 @@ func TestMethod_IsExported(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			t.Parallel()
 
-			method := newMethod(nil, tc.Ident, nil, false)
-			exported := method.IsExported()
+			exported := tc.Method.IsExported()
 			assert.Equal(t, tc.Expected, exported)
 		})
 	}
 }
 
 func TestMethod_Parameters(t *testing.T) {
+	var (
+		intType     types.Type = &fakeType{"int"}
+		float64Type types.Type = &fakeType{"float64"}
+	)
+
 	p := &packages.Package{}
 	cases := []struct {
 		Name     string
-		FuncType *ast.FuncType
+		Method   Method
 		Expected []Value
 	}{
 		{
-			Name: "success",
-			FuncType: &ast.FuncType{Params: &ast.FieldList{List: []*ast.Field{
+			Name: "AST success",
+			Method: newASTMethod(p, nil, &ast.FuncType{Params: &ast.FieldList{List: []*ast.Field{
 				{
 					Names: []*ast.Ident{ast.NewIdent("a"), ast.NewIdent("b")},
 					Type:  ast.NewIdent("int"),
@@ -118,11 +99,24 @@ func TestMethod_Parameters(t *testing.T) {
 					Names: []*ast.Ident{ast.NewIdent("c")},
 					Type:  ast.NewIdent("float64"),
 				},
-			}}},
+			}}}, false),
 			Expected: []Value{
-				newValue(p, ast.NewIdent("a"), ast.NewIdent("int")),
-				newValue(p, ast.NewIdent("b"), ast.NewIdent("int")),
-				newValue(p, ast.NewIdent("c"), ast.NewIdent("float64")),
+				newASTValue(p, ast.NewIdent("a"), ast.NewIdent("int")),
+				newASTValue(p, ast.NewIdent("b"), ast.NewIdent("int")),
+				newASTValue(p, ast.NewIdent("c"), ast.NewIdent("float64")),
+			},
+		},
+		{
+			Name: "types success",
+			Method: newTypesMethod(types.NewFunc(0, nil, "", types.NewSignatureType(nil, nil, nil, types.NewTuple(
+				types.NewParam(0, nil, "a", intType),
+				types.NewParam(0, nil, "b", intType),
+				types.NewParam(0, nil, "c", float64Type),
+			), nil, false))),
+			Expected: []Value{
+				newTypesValue(types.NewParam(0, nil, "a", intType)),
+				newTypesValue(types.NewParam(0, nil, "b", intType)),
+				newTypesValue(types.NewParam(0, nil, "c", float64Type)),
 			},
 		},
 	}
@@ -132,23 +126,27 @@ func TestMethod_Parameters(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			t.Parallel()
 
-			method := newMethod(p, nil, tc.FuncType, false)
-			parameters := method.Parameters()
+			parameters := tc.Method.Parameters()
 			assert.Equal(t, tc.Expected, parameters)
 		})
 	}
 }
 
 func TestMethod_Results(t *testing.T) {
+	var (
+		intType   types.Type = &fakeType{"int"}
+		errorType types.Type = &fakeType{"error"}
+	)
+
 	p := &packages.Package{}
 	cases := []struct {
 		Name     string
-		FuncType *ast.FuncType
+		Method   Method
 		Expected []Value
 	}{
 		{
-			Name: "success",
-			FuncType: &ast.FuncType{Results: &ast.FieldList{List: []*ast.Field{
+			Name: "AST success",
+			Method: newASTMethod(p, nil, &ast.FuncType{Results: &ast.FieldList{List: []*ast.Field{
 				{
 					Names: []*ast.Ident{ast.NewIdent("a"), ast.NewIdent("b")},
 					Type:  ast.NewIdent("int"),
@@ -157,11 +155,24 @@ func TestMethod_Results(t *testing.T) {
 					Names: []*ast.Ident{ast.NewIdent("err")},
 					Type:  ast.NewIdent("error"),
 				},
-			}}},
+			}}}, false),
 			Expected: []Value{
-				newValue(p, ast.NewIdent("a"), ast.NewIdent("int")),
-				newValue(p, ast.NewIdent("b"), ast.NewIdent("int")),
-				newValue(p, ast.NewIdent("err"), ast.NewIdent("error")),
+				newASTValue(p, ast.NewIdent("a"), ast.NewIdent("int")),
+				newASTValue(p, ast.NewIdent("b"), ast.NewIdent("int")),
+				newASTValue(p, ast.NewIdent("err"), ast.NewIdent("error")),
+			},
+		},
+		{
+			Name: "types success",
+			Method: newTypesMethod(types.NewFunc(0, nil, "", types.NewSignatureType(nil, nil, nil, nil, types.NewTuple(
+				types.NewVar(0, nil, "a", intType),
+				types.NewVar(0, nil, "b", intType),
+				types.NewVar(0, nil, "err", errorType),
+			), false))),
+			Expected: []Value{
+				newTypesValue(types.NewVar(0, nil, "a", intType)),
+				newTypesValue(types.NewVar(0, nil, "b", intType)),
+				newTypesValue(types.NewVar(0, nil, "err", errorType)),
 			},
 		},
 	}
@@ -171,26 +182,42 @@ func TestMethod_Results(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			t.Parallel()
 
-			method := newMethod(p, nil, tc.FuncType, false)
-			results := method.Results()
+			results := tc.Method.Results()
 			assert.Equal(t, tc.Expected, results)
 		})
 	}
 }
 
 func TestMethod_Variadic(t *testing.T) {
+	var intType types.Type = &fakeType{"int"}
+
 	cases := []struct {
-		Name               string
-		Variadic, Expected bool
+		Name     string
+		Method   Method
+		Expected bool
 	}{
 		{
-			Name:     "variadic",
-			Variadic: true,
+			Name:     "AST variadic",
+			Method:   newASTMethod(nil, nil, nil, true),
 			Expected: true,
 		},
 		{
-			Name:     "not variadic",
-			Variadic: false,
+			Name:     "AST not variadic",
+			Method:   newASTMethod(nil, nil, nil, false),
+			Expected: false,
+		},
+		{
+			Name: "types variadic",
+			Method: newTypesMethod(types.NewFunc(0, nil, "", types.NewSignatureType(nil, nil, nil, types.NewTuple(
+				types.NewParam(0, nil, "a", types.NewSlice(intType)),
+			), nil, true))),
+			Expected: true,
+		},
+		{
+			Name: "types not variadic",
+			Method: newTypesMethod(types.NewFunc(0, nil, "", types.NewSignatureType(nil, nil, nil, types.NewTuple(
+				types.NewParam(0, nil, "a", types.NewSlice(intType)),
+			), nil, false))),
 			Expected: false,
 		},
 	}
@@ -200,8 +227,7 @@ func TestMethod_Variadic(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			t.Parallel()
 
-			method := newMethod(nil, nil, nil, tc.Variadic)
-			variadic := method.Variadic()
+			variadic := tc.Method.Variadic()
 			assert.Equal(t, tc.Expected, variadic)
 		})
 	}

--- a/mock/cmd/cmg/pkg/parse/package_test.go
+++ b/mock/cmd/cmg/pkg/parse/package_test.go
@@ -143,6 +143,8 @@ func TestPackage_Interfaces(t *testing.T) {
 				IsExported bool
 			}{
 				{Name: "Doer", File: "doer.go", IsExported: true},
+				{Name: "EmbeddedDoer", File: "doer.go", IsExported: true},
+				{Name: "ExternalEmbeddedDoer", File: "doer.go", IsExported: true},
 				{Name: "doer", File: "doer.go", IsExported: false},
 			},
 		},

--- a/mock/cmd/cmg/pkg/parse/value.go
+++ b/mock/cmd/cmg/pkg/parse/value.go
@@ -13,24 +13,40 @@ type (
 		Type() types.Type
 	}
 
-	value struct {
+	astValue struct {
 		p         *packages.Package
 		ident     *ast.Ident
 		valueType ast.Expr
 	}
+
+	typesValue struct {
+		v *types.Var
+	}
 )
 
-func newValue(p *packages.Package, ident *ast.Ident, valueType ast.Expr) Value {
-	return &value{p: p, ident: ident, valueType: valueType}
+func newASTValue(p *packages.Package, ident *ast.Ident, valueType ast.Expr) Value {
+	return &astValue{p: p, ident: ident, valueType: valueType}
 }
 
-func (v *value) Name() string {
-	if v.ident != nil {
-		return v.ident.Name
+func (av *astValue) Name() string {
+	if av.ident != nil {
+		return av.ident.Name
 	}
 	return ""
 }
 
-func (v *value) Type() types.Type {
-	return v.p.TypesInfo.Types[v.valueType].Type
+func (av *astValue) Type() types.Type {
+	return av.p.TypesInfo.Types[av.valueType].Type
+}
+
+func newTypesValue(v *types.Var) Value {
+	return &typesValue{v: v}
+}
+
+func (tv *typesValue) Name() string {
+	return tv.v.Name()
+}
+
+func (tv *typesValue) Type() types.Type {
+	return tv.v.Type()
 }

--- a/mock/cmd/cmg/pkg/parse/value_test.go
+++ b/mock/cmd/cmg/pkg/parse/value_test.go
@@ -26,16 +26,21 @@ func (t *fakeType) String() string {
 func TestValue_Name(t *testing.T) {
 	cases := []struct {
 		Name, Expected string
-		Ident          *ast.Ident
+		Value          Value
 	}{
 		{
-			Name:     "empty",
-			Ident:    nil,
+			Name:     "AST empty",
+			Value:    newASTValue(nil, nil, nil),
 			Expected: "",
 		},
 		{
-			Name:     "success",
-			Ident:    ast.NewIdent("a"),
+			Name:     "AST success",
+			Value:    newASTValue(nil, ast.NewIdent("a"), nil),
+			Expected: "a",
+		},
+		{
+			Name:     "types success",
+			Value:    newTypesValue(types.NewVar(0, nil, "a", nil)),
 			Expected: "a",
 		},
 	}
@@ -45,8 +50,7 @@ func TestValue_Name(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			t.Parallel()
 
-			value := newValue(nil, tc.Ident, nil)
-			name := value.Name()
+			name := tc.Value.Name()
 			assert.Equal(t, tc.Expected, name)
 		})
 	}
@@ -59,18 +63,21 @@ func TestValue_Type(t *testing.T) {
 	)
 
 	cases := []struct {
-		Name      string
-		Package   *packages.Package
-		ValueType ast.Expr
-		Expected  types.Type
+		Name     string
+		Value    Value
+		Expected types.Type
 	}{
 		{
-			Name: "success",
-			Package: &packages.Package{TypesInfo: &types.Info{Types: map[ast.Expr]types.TypeAndValue{
+			Name: "AST success",
+			Value: newASTValue(&packages.Package{TypesInfo: &types.Info{Types: map[ast.Expr]types.TypeAndValue{
 				stringIdent: {Type: stringType},
-			}}},
-			ValueType: stringIdent,
-			Expected:  stringType,
+			}}}, nil, stringIdent),
+			Expected: stringType,
+		},
+		{
+			Name:     "types success",
+			Value:    newTypesValue(types.NewVar(0, nil, "", stringType)),
+			Expected: stringType,
 		},
 	}
 
@@ -79,8 +86,7 @@ func TestValue_Type(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			t.Parallel()
 
-			value := newValue(tc.Package, nil, tc.ValueType)
-			typ := value.Type()
+			typ := tc.Value.Type()
 			assert.Equal(t, tc.Expected, typ)
 		})
 	}

--- a/mock/cmd/cmg/pkg/version.go
+++ b/mock/cmd/cmg/pkg/version.go
@@ -10,7 +10,7 @@ const (
 	// Minor version number
 	Minor = 18
 	// Build number
-	Build = 1
+	Build = 2
 	// Suffix - set to empty string in release tag commits.
 	Suffix = ""
 )


### PR DESCRIPTION
Before, Clue Mock Generator would not include the methods from embedded interfaces, for example:

```golang
package something

import (
    "goa.design/clue/health"
)

type Client interface {
    Get() (string, error)

    health.Pinger
}
```

Would not include the methods from `health.Pinger` in the generated mock. Now it will!