### PR TITLE
switch to chi router in weather example

### DIFF
--- a/example/weather/services/front/cmd/front/main.go
+++ b/example/weather/services/front/cmd/front/main.go
@@ -11,7 +11,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/go-chi/chi/v5"
 	"goa.design/clue/debug"
 	"goa.design/clue/health"
 	"goa.design/clue/log"
@@ -71,9 +70,10 @@ func main() {
 	}
 
 	// 3. Setup metrics
+	mux := goahttp.NewMuxer()
 	ctx = metrics.Context(ctx, genfront.ServiceName,
 		metrics.WithRouteResolver(func(r *http.Request) string {
-			return chi.RouteContext(r.Context()).RoutePattern()
+			return mux.ResolvePattern(r)
 		}),
 	)
 
@@ -106,7 +106,6 @@ func main() {
 	endpoints.Use(log.Endpoint)
 
 	// 5. Create transport
-	mux := goahttp.NewMuxer()
 	debug.MountDebugLogEnabler(debug.Adapt(mux))
 	mux.Use(metrics.HTTP(ctx))
 	handler := trace.HTTP(ctx)(mux)                                            // 4. Trace request

--- a/example/weather/services/front/cmd/front/main.go
+++ b/example/weather/services/front/cmd/front/main.go
@@ -11,7 +11,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/dimfeld/httptreemux/v5"
+	"github.com/go-chi/chi/v5"
 	"goa.design/clue/debug"
 	"goa.design/clue/health"
 	"goa.design/clue/log"
@@ -73,7 +73,7 @@ func main() {
 	// 3. Setup metrics
 	ctx = metrics.Context(ctx, genfront.ServiceName,
 		metrics.WithRouteResolver(func(r *http.Request) string {
-			return httptreemux.ContextRoute(r.Context())
+			return chi.RouteContext(r.Context()).RoutePattern()
 		}),
 	)
 

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ toolchain go1.21.0
 
 require (
 	github.com/aws/smithy-go v1.14.2
-	github.com/go-chi/chi/v5 v5.0.10
 	github.com/go-logfmt/logfmt v0.6.0
 	github.com/prometheus/client_golang v1.16.0
 	github.com/prometheus/client_model v0.4.0
@@ -35,6 +34,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dimfeld/httppath v0.0.0-20170720192232-ee938bf73598 // indirect
 	github.com/felixge/httpsnoop v1.0.3 // indirect
+	github.com/go-chi/chi/v5 v5.0.10 // indirect
 	github.com/go-logr/logr v1.2.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.21.0
 
 require (
 	github.com/aws/smithy-go v1.14.2
-	github.com/dimfeld/httptreemux/v5 v5.5.0
+	github.com/go-chi/chi/v5 v5.0.10
 	github.com/go-logfmt/logfmt v0.6.0
 	github.com/prometheus/client_golang v1.16.0
 	github.com/prometheus/client_model v0.4.0
@@ -35,7 +35,6 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dimfeld/httppath v0.0.0-20170720192232-ee938bf73598 // indirect
 	github.com/felixge/httpsnoop v1.0.3 // indirect
-	github.com/go-chi/chi/v5 v5.0.10 // indirect
 	github.com/go-logr/logr v1.2.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -20,8 +20,6 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dimfeld/httppath v0.0.0-20170720192232-ee938bf73598 h1:MGKhKyiYrvMDZsmLR/+RGffQSXwEkXgfLSA08qDn9AI=
 github.com/dimfeld/httppath v0.0.0-20170720192232-ee938bf73598/go.mod h1:0FpDmbrt36utu8jEmeU05dPC9AB5tsLYVVi+ZHfyuwI=
-github.com/dimfeld/httptreemux/v5 v5.5.0 h1:p8jkiMrCuZ0CmhwYLcbNbl7DDo21fozhKHQ2PccwOFQ=
-github.com/dimfeld/httptreemux/v5 v5.5.0/go.mod h1:QeEylH57C0v3VO0tkKraVz9oD3Uu93CKPnTLbsidvSw=
 github.com/envoyproxy/protoc-gen-validate v1.0.2 h1:QkIBuU5k+x7/QXPvPPnWXWlCdaBFApVqftFV6k087DA=
 github.com/envoyproxy/protoc-gen-validate v1.0.2/go.mod h1:GpiZQP3dDbg4JouG/NNS7QWXpgx6x8QiMKdmN72jogE=
 github.com/felixge/httpsnoop v1.0.3 h1:s/nj+GCswXYzN5v2DpNMuMQYe+0DDwt5WVCU6CWBdXk=

--- a/go.work.sum
+++ b/go.work.sum
@@ -134,6 +134,7 @@ github.com/client9/misspell v0.3.4 h1:ta993UF76GwbvJcIo3Y68y/M3WxlpEHPWIGDkJYwzJ
 github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4 h1:hzAQntlaYRkVSFEfj9OTWlVV1H155FMD8BTKktLv0QI=
 github.com/cncf/udpa/go v0.0.0-20220112060539-c52dc94e7fbe/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1 h1:zH8ljVhhq7yC0MIeUL/IviMtY8hx2mK8cN9wEYb8ggw=
+github.com/dimfeld/httptreemux/v5 v5.5.0/go.mod h1:QeEylH57C0v3VO0tkKraVz9oD3Uu93CKPnTLbsidvSw=
 github.com/envoyproxy/go-control-plane v0.10.2-0.20220325020618-49ff273808a1 h1:xvqufLtNVwAhN8NMyWklVgxnWohi+wtMGQMhtxexlm0=
 github.com/envoyproxy/protoc-gen-validate v0.1.0 h1:EQciDnbrYxy13PgWoY8AqoxGiPrpgBZ1R8UNe3ddc+A=
 github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=


### PR DESCRIPTION
As part of Goa v3.13.0, the default router was switched to `chi` (Ref: https://github.com/goadesign/goa/pull/3346)
This PR updates the weather example to use chi.