### PR TITLE
Remove peer attributes from gRPC

### DIFF
--- a/metrics/context.go
+++ b/metrics/context.go
@@ -81,10 +81,6 @@ const (
 	labelHTTPPath = "http_path"
 	// labelHTTPStatusCode is the name of the label containing the HTTP status code.
 	labelHTTPStatusCode = "http_status_code"
-	// labelPeerIP is the peer host ip.
-	labelPeerIP = "net_peer_ip"
-	// labelPeerPort is the peer host port
-	labelPeerPort = "net_peer_port"
 	// labelRPCService is the name of the RPC service label.
 	labelRPCService = "rpc_service"
 	// labelRPCMethod is the name of the RPC method label.
@@ -110,11 +106,11 @@ var (
 	httpActiveRequestsLabels = []string{labelHTTPVerb, labelHTTPHost, labelHTTPPath}
 
 	// rpcLabels is the default set of dynamic metric labels
-	rpcLabels = []string{labelPeerIP, labelPeerPort, labelRPCService, labelRPCMethod, labelRPCStatusCode}
+	rpcLabels = []string{labelRPCService, labelRPCMethod, labelRPCStatusCode}
 
 	// NoCode is the set of dynamic labels used for active gRPC requests
 	// metric and stream message and result size metrics.
-	rpcNoCodeLabels = []string{labelPeerIP, labelPeerPort, labelRPCService, labelRPCMethod}
+	rpcNoCodeLabels = []string{labelRPCService, labelRPCMethod}
 )
 
 // Context initializes the given context for the HTTP, UnaryInterceptor and

--- a/metrics/grpc.go
+++ b/metrics/grpc.go
@@ -133,19 +133,6 @@ func (s *streamWrapper) SendMsg(m interface{}) error {
 	return s.ServerStream.SendMsg(m)
 }
 
-func parseAddr(addr string) (ip, port string) {
-	if addr == "" {
-		return "", ""
-	}
-	if addr[0] == ':' {
-		return "", addr[1:]
-	}
-	if idx := strings.LastIndex(addr, ":"); idx > 0 {
-		return addr[:idx], addr[idx+1:]
-	}
-	return addr, ""
-}
-
 func parseGRPCFullMethodName(fullMethodName string) (serviceName, methodName string) {
 	if idx := strings.LastIndex(fullMethodName, "."); idx >= 0 {
 		fullMethodName = fullMethodName[idx+1:]

--- a/metrics/grpc.go
+++ b/metrics/grpc.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 )
@@ -26,20 +25,19 @@ type (
 // requests. The context must have been initialized with metrics.Context. The
 // returned interceptor adds the following metrics:
 //
-//    * `grpc.server.duration`: Histogram of request durations in milliseconds.
-//    * `grpc.server.active_requests`: UpDownCounter of active requests.
-//    * `grpc.server.request.size`: Histogram of request sizes in bytes.
-//    * `grpc.server.response.size`: Histogram of response sizes in bytes.
+//   - `grpc.server.duration`: Histogram of request durations in milliseconds.
+//   - `grpc.server.active_requests`: UpDownCounter of active requests.
+//   - `grpc.server.request.size`: Histogram of request sizes in bytes.
+//   - `grpc.server.response.size`: Histogram of response sizes in bytes.
 //
 // All the metrics have the following labels:
 //
-//    * `goa.method`: The method name as specified in the Goa design.
-//    * `goa.service`: The service name as specified in the Goa design.
-//    * `net.peer.name`: The peer name.
-//    * `rpc.system`: A stream identifying the remoting system (e.g. `grpc`).
-//    * `rpc.service`: Name of RPC service.
-//    * `rpc.method`: Name of RPC method.
-//    * `rpc.status_code`: The response status code.
+//   - `goa.method`: The method name as specified in the Goa design.
+//   - `goa.service`: The service name as specified in the Goa design.
+//   - `rpc.system`: A stream identifying the remoting system (e.g. `grpc`).
+//   - `rpc.service`: Name of RPC service.
+//   - `rpc.method`: Name of RPC method.
+//   - `rpc.status_code`: The response status code.
 //
 // Errors collecting or serving metrics are logged to the logger in the context
 // if any.
@@ -53,14 +51,6 @@ func UnaryServerInterceptor(ctx context.Context) grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
 		service, method := parseGRPCFullMethodName(info.FullMethod)
 		labels := prometheus.Labels{labelRPCMethod: method, labelRPCService: service}
-		if p, ok := peer.FromContext(ctx); ok {
-			ip, port := parseAddr(p.Addr.String())
-			labels[labelPeerIP] = ip
-			labels[labelPeerPort] = port
-		} else {
-			labels[labelPeerIP] = ""
-			labels[labelPeerPort] = ""
-		}
 		metrics.ActiveRequests.With(labels).Add(1)
 		defer metrics.ActiveRequests.With(labels).Sub(1)
 
@@ -85,19 +75,18 @@ func UnaryServerInterceptor(ctx context.Context) grpc.UnaryServerInterceptor {
 // requests. The context must have been initialized with Context. The returned
 // interceptor adds the following metrics:
 //
-//    * `grpc.server.active_requests`: UpDownCounter of active requests.
-//    * `grpc.server.request.size`: Histogram of request sizes in bytes.
-//    * `grpc.server.response.size`: Histogram of response sizes in bytes.
+//   - `grpc.server.active_requests`: UpDownCounter of active requests.
+//   - `grpc.server.request.size`: Histogram of request sizes in bytes.
+//   - `grpc.server.response.size`: Histogram of response sizes in bytes.
 //
 // All the metrics have the following labels:
 //
-//    * `goa.method`: The method name as specified in the Goa design.
-//    * `goa.service`: The service name as specified in the Goa design.
-//    * `net.peer.name`: The peer name.
-//    * `rpc.system`: A stream identifying the remoting system (e.g. `grpc`).
-//    * `rpc.service`: Name of RPC service.
-//    * `rpc.method`: Name of RPC method.
-//    * `rpc.status_code`: The response status code.
+//   - `goa.method`: The method name as specified in the Goa design.
+//   - `goa.service`: The service name as specified in the Goa design.
+//   - `rpc.system`: A stream identifying the remoting system (e.g. `grpc`).
+//   - `rpc.service`: Name of RPC service.
+//   - `rpc.method`: Name of RPC method.
+//   - `rpc.status_code`: The response status code.
 //
 // Errors collecting or serving metrics are logged to the logger in the context
 // if any.
@@ -111,14 +100,6 @@ func StreamServerInterceptor(ctx context.Context) grpc.StreamServerInterceptor {
 	return func(srv interface{}, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
 		service, method := parseGRPCFullMethodName(info.FullMethod)
 		labels := prometheus.Labels{labelRPCMethod: method, labelRPCService: service}
-		if p, ok := peer.FromContext(stream.Context()); ok {
-			ip, port := parseAddr(p.Addr.String())
-			labels[labelPeerIP] = ip
-			labels[labelPeerPort] = port
-		} else {
-			labels[labelPeerIP] = ""
-			labels[labelPeerPort] = ""
-		}
 		metrics.ActiveRequests.With(labels).Add(1)
 		defer metrics.ActiveRequests.With(labels).Sub(1)
 


### PR DESCRIPTION
To prevent potential DDOS attacks.
See https://github.com/open-telemetry/opentelemetry-go-contrib/pull/4322