### PR TITLE
Fix debug pprof handler routing

### DIFF
--- a/debug/debug.go
+++ b/debug/debug.go
@@ -95,6 +95,13 @@ func MountPprofHandlers(mux Muxer, opts ...PprofOption) {
 	mux.HandleFunc(o.prefix+"profile", pprof.Profile)
 	mux.HandleFunc(o.prefix+"symbol", pprof.Symbol)
 	mux.HandleFunc(o.prefix+"trace", pprof.Trace)
+
+	mux.Handle(o.prefix+"goroutine", pprof.Handler("goroutine"))
+	mux.Handle(o.prefix+"threadcreate", pprof.Handler("threadcreate"))
+	mux.Handle(o.prefix+"mutex", pprof.Handler("mutex"))
+	mux.Handle(o.prefix+"heap", pprof.Handler("heap"))
+	mux.Handle(o.prefix+"block", pprof.Handler("block"))
+	mux.Handle(o.prefix+"allocs", pprof.Handler("allocs"))
 }
 
 // LogPayloads returns a Goa endpoint middleware that logs request payloads and

--- a/debug/debug_test.go
+++ b/debug/debug_test.go
@@ -12,6 +12,7 @@ import (
 	"goa.design/clue/internal/testsvc"
 	"goa.design/clue/internal/testsvc/gen/test"
 	"goa.design/clue/log"
+	goahttp "goa.design/goa/v3/http"
 )
 
 func TestMountDebugLogEnabler(t *testing.T) {
@@ -76,10 +77,10 @@ func TestMountDebugLogEnabler(t *testing.T) {
 }
 
 func TestMountPprofHandlers(t *testing.T) {
-	mux := http.NewServeMux()
-	MountPprofHandlers(mux)
-	MountPprofHandlers(mux, WithPrefix("test"))
-	var handler http.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	mux := goahttp.NewMuxer()
+	MountPprofHandlers(Adapt(mux))
+	MountPprofHandlers(Adapt(mux), WithPrefix("test"))
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/" {
 			w.WriteHeader(http.StatusNotFound)
 			return
@@ -87,7 +88,7 @@ func TestMountPprofHandlers(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte("OK")) // nolint: errcheck
 	})
-	mux.Handle("/", handler)
+	mux.Handle(http.MethodGet, "/", handler)
 	ts := httptest.NewServer(mux)
 	defer ts.Close()
 


### PR DESCRIPTION
Hey folks 👋🏻 Just started using goa.design and I really like it so far!

While using the clue debug handlers, I noticed that the pprof profile handlers like `goroutine` and `mutex`, other than `cmdline`, `profile`, `symbol` and `trace`, were not actually working and returned 404.

After some digging and testing, it seems that's because those profile handlers are not explicitly mounted on the mux. While this works for `http.NewServeMux` (like in `debug_test.go`), it doesn't actually work with `chi.Mux` or even gorilla `mux.Router` - not entirely sure why, but I'd bet it's something to do with how routing decisions are implemented in the stdlib vs. third-party libraries.

You can see that here in this test:
```go
type ChiMuxWrapper struct {
	*chi.Mux
}

func (w *ChiMuxWrapper) HandleFunc(pattern string, handler func(http.ResponseWriter, *http.Request)) {
	w.Mux.HandleFunc(pattern, handler)
}

func TestMountPprofHandlers(t *testing.T) {
	mux := chi.NewRouter()
	MountPprofHandlers(&ChiMuxWrapper{mux})
	MountPprofHandlers(&ChiMuxWrapper{mux}, WithPrefix("test"))
	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
		if r.URL.Path != "/" {
			w.WriteHeader(http.StatusNotFound)
			return
		}
		w.WriteHeader(http.StatusOK)
		w.Write([]byte("OK")) // nolint: errcheck
	})
	mux.Handle("/", handler)
	ts := httptest.NewServer(mux)
	defer ts.Close()

	status, resp := makeRequest(t, ts.URL)
	if status != http.StatusOK {
		t.Errorf("got status %d, expected %d", status, http.StatusOK)
	}
	if resp != "OK" {
		t.Errorf("got body %q, expected %q", resp, "OK")
	}

	paths := []string{
		"/debug/pprof/",
		"/test/",
		"/debug/pprof/allocs",
		"/debug/pprof/block",
		"/debug/pprof/cmdline",
		"/debug/pprof/goroutine",
		"/debug/pprof/heap",
		"/debug/pprof/mutex",
		// "/debug/pprof/profile?seconds=1", # Takes too long to run on each test
		"/debug/pprof/symbol",
		"/debug/pprof/threadcreate",
		// "/debug/pprof/trace", # Takes too long to run on each test
	}
	for _, path := range paths {
		status, resp = makeRequest(t, ts.URL+path)
		if status != http.StatusOK {
			t.Errorf("got status %d, expected %d", status, http.StatusOK)
		}
		if resp == "" {
			t.Errorf("got body %q, expected non-empty", resp)
		}
	}
}
```

I've proposed a fix for this by explicitly mounting each pprof handler, similar to what chi's `middleware.Profiler` does: https://github.com/go-chi/chi/blob/master/middleware/profiler.go

Let me know what you think!