### PR TITLE
Suppress request start/end logs unless there is an error

### DIFF
--- a/log/grpc.go
+++ b/log/grpc.go
@@ -59,7 +59,7 @@ func UnaryServerInterceptor(logCtx context.Context, opts ...GRPCLogOption) grpc.
 		then := time.Now()
 		svcKV := KV{K: GRPCServiceKey, V: path.Dir(info.FullMethod)[1:]}
 		methKV := KV{K: GRPCMethodKey, V: path.Base(info.FullMethod)}
-		Print(ctx, KV{MessageKey, "start"}, svcKV, methKV)
+		Info(ctx, KV{MessageKey, "start"}, svcKV, methKV)
 
 		res, err := handler(ctx, req)
 
@@ -72,7 +72,7 @@ func UnaryServerInterceptor(logCtx context.Context, opts ...GRPCLogOption) grpc.
 			Error(ctx, err, svcKV, methKV, statKV, codeKV, durKV)
 			return res, err
 		}
-		Print(ctx, KV{MessageKey, "end"}, svcKV, methKV, codeKV, durKV)
+		Info(ctx, KV{MessageKey, "end"}, svcKV, methKV, codeKV, durKV)
 		return res, err
 	}
 }
@@ -104,7 +104,7 @@ func StreamServerInterceptor(logCtx context.Context, opts ...GRPCLogOption) grpc
 		then := time.Now()
 		svcKV := KV{K: GRPCServiceKey, V: path.Dir(info.FullMethod)[1:]}
 		methKV := KV{K: GRPCMethodKey, V: path.Base(info.FullMethod)}
-		Print(ctx, KV{MessageKey, "start"}, svcKV, methKV)
+		Info(ctx, KV{MessageKey, "start"}, svcKV, methKV)
 
 		err := handler(srv, stream)
 
@@ -117,7 +117,7 @@ func StreamServerInterceptor(logCtx context.Context, opts ...GRPCLogOption) grpc
 			Error(ctx, err, svcKV, methKV, statKV, codeKV, durKV)
 			return err
 		}
-		Print(ctx, KV{MessageKey, "end"}, svcKV, methKV, codeKV, durKV)
+		Info(ctx, KV{MessageKey, "end"}, svcKV, methKV, codeKV, durKV)
 		return err
 	}
 }
@@ -140,7 +140,7 @@ func UnaryClientInterceptor(opts ...GRPCLogOption) grpc.UnaryClientInterceptor {
 		then := time.Now()
 		svcKV := KV{K: GRPCServiceKey, V: path.Dir(fullmethod)[1:]}
 		methKV := KV{K: GRPCMethodKey, V: path.Base(fullmethod)}
-		Print(ctx, KV{K: MessageKey, V: "start"}, svcKV, methKV)
+		Info(ctx, KV{K: MessageKey, V: "start"}, svcKV, methKV)
 
 		err := invoker(ctx, fullmethod, req, reply, cc, opts...)
 
@@ -153,7 +153,7 @@ func UnaryClientInterceptor(opts ...GRPCLogOption) grpc.UnaryClientInterceptor {
 			Error(ctx, err, svcKV, methKV, statKV, codeKV, durKV)
 			return err
 		}
-		Print(ctx, KV{K: MessageKey, V: "end"}, svcKV, methKV, codeKV, durKV)
+		Info(ctx, KV{K: MessageKey, V: "end"}, svcKV, methKV, codeKV, durKV)
 		return err
 	}
 }
@@ -176,7 +176,7 @@ func StreamClientInterceptor(opts ...GRPCLogOption) grpc.StreamClientInterceptor
 		then := time.Now()
 		svcKV := KV{K: GRPCServiceKey, V: path.Dir(fullmethod)[1:]}
 		methKV := KV{K: GRPCMethodKey, V: path.Base(fullmethod)}
-		Print(ctx, KV{K: MessageKey, V: "start"}, svcKV, methKV)
+		Info(ctx, KV{K: MessageKey, V: "start"}, svcKV, methKV)
 
 		stream, err := streamer(ctx, desc, cc, fullmethod, opts...)
 
@@ -189,7 +189,7 @@ func StreamClientInterceptor(opts ...GRPCLogOption) grpc.StreamClientInterceptor
 			Error(ctx, err, svcKV, methKV, statKV, codeKV, durKV)
 			return stream, err
 		}
-		Print(ctx, KV{K: MessageKey, V: "end"}, svcKV, methKV, codeKV, durKV)
+		Info(ctx, KV{K: MessageKey, V: "end"}, svcKV, methKV, codeKV, durKV)
 		return stream, err
 	}
 }

--- a/log/http.go
+++ b/log/http.go
@@ -82,7 +82,7 @@ func HTTP(logCtx context.Context, opts ...HTTPLogOption) func(http.Handler) http
 			methKV := KV{K: HTTPMethodKey, V: req.Method}
 			urlKV := KV{K: HTTPURLKey, V: req.URL.String()}
 			fromKV := KV{K: HTTPFromKey, V: from(req)}
-			Print(ctx, KV{K: MessageKey, V: "start"}, methKV, urlKV, fromKV)
+			Info(ctx, KV{K: MessageKey, V: "start"}, methKV, urlKV, fromKV)
 
 			rw := &responseCapture{ResponseWriter: w}
 			started := timeNow()
@@ -91,7 +91,7 @@ func HTTP(logCtx context.Context, opts ...HTTPLogOption) func(http.Handler) http
 			statusKV := KV{K: HTTPStatusKey, V: rw.StatusCode}
 			durKV := KV{K: HTTPDurationKey, V: timeSince(started).Milliseconds()}
 			bytesKV := KV{K: HTTPBytesKey, V: rw.ContentLength}
-			Print(ctx, KV{K: MessageKey, V: "end"}, methKV, urlKV, statusKV, durKV, bytesKV)
+			Info(ctx, KV{K: MessageKey, V: "end"}, methKV, urlKV, statusKV, durKV, bytesKV)
 		})
 	}
 }


### PR DESCRIPTION
Problem: I am using an observability stack, yet my server logs are cluttered with thousands of useless`start/end` lines. This makes it hard to see when there is an actual error if I am tailing server logs (and the only time I tail logs is when I want to see an actual error in realtime -- otherwise I use tracing!)

Solution: suppress start/end logs unless there is an error.

The tests are broken; I will fix them if the team agrees to accept this change. Thought I would raise the issue first & discuss.