### PR TITLE
Fix example for clue.NewConfig

### DIFF
--- a/clue/config.go
+++ b/clue/config.go
@@ -67,7 +67,7 @@ func ConfigureOpenTelemetry(ctx context.Context, cfg *Config) {
 //	if err != nil {
 //		return err
 //	}
-//	cfg := clue.NewConfig("mysvc", "1.0.0", metricExporter, spanExporter)
+//	cfg := clue.NewConfig(ctx, "mysvc", "1.0.0", metricExporter, spanExporter)
 func NewConfig(
 	ctx context.Context,
 	svcName string,


### PR DESCRIPTION
Fix the example for `clue.NewConfig` to include the context parameter.