### PR TITLE
Fix `cmg` always logging failed to remove temporary file errors

### DIFF
--- a/mock/cmd/cmg/pkg/generate.go
+++ b/mock/cmd/cmg/pkg/generate.go
@@ -2,7 +2,9 @@ package cluemockgen
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -106,7 +108,7 @@ func generateFile(ctx context.Context, p parse.Package, file string, interfaces 
 		return err
 	}
 	defer func() {
-		if removeErr := os.Remove(f.Name()); removeErr != nil {
+		if removeErr := os.Remove(f.Name()); removeErr != nil && !errors.Is(removeErr, fs.ErrNotExist) {
 			log.Error(ctx, fmt.Errorf("failed to remove temporary file: %w", removeErr))
 		}
 	}()


### PR DESCRIPTION
- #545 inadvertently introduced a bug where a call to `os.Remove` on a temporary file that should have been moved would have been allowed to fail started becoming logged as an error.
- This fixes the issue by making sure that the error returned by `os.Remove` is not `fs.ErrNotExist` which is an acceptable error in this case.