### PR TITLE
log.go: Export log color codes

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -49,6 +49,14 @@ var (
 	osExit    = os.Exit
 )
 
+// Export color codes
+var (
+	ColorSeverityDebug = "\033[37m"
+	ColorSeverityInfo  = "\033[34m"
+	ColorSeverityWarn  = "\033[33m"
+	ColorSeverityError = "\033[1;31m"
+)
+
 // Debug writes the key/value pairs to the log output if the log context is
 // configured to log debug messages (via WithDebug).
 func Debug(ctx context.Context, keyvals ...Fielder) {
@@ -253,13 +261,13 @@ func (l Severity) Code() string {
 func (l Severity) Color() string {
 	switch l {
 	case SeverityDebug:
-		return "\033[37m"
+		return ColorSeverityDebug
 	case SeverityInfo:
-		return "\033[34m"
+		return ColorSeverityInfo
 	case SeverityWarn:
-		return "\033[33m"
+		return ColorSeverityWarn
 	case SeverityError:
-		return "\033[1;31m"
+		return ColorSeverityError
 	default:
 		return ""
 	}


### PR DESCRIPTION
  This gives an application to manipulate the color codes.  This was done because the default for SeverityInfo (blue) was difficult to read when displayed on a console black background.

In my case, I'm swapping out SeverityInfo blue with cyan color ("\033[36m") which makes its log output much easier to read.

On a different branch, I'm defining colors for:
1. ColorBlue
2. ColorBlueBold
3. ColorCyan

but those little color helpers are not in this PR in order to keep it tightly focused to the original.  If you want me to include them, your can look at my FQdevel branch and I can fold that into this PR.  I just didn't know if you wanted any extra noise in this submission.